### PR TITLE
Fall back to postDataBuffer() when postData() is null

### DIFF
--- a/src/Client/RequestConverter.php
+++ b/src/Client/RequestConverter.php
@@ -37,6 +37,9 @@ class RequestConverter
         $method = $playwrightRequest->method();
         $headers = $playwrightRequest->headers();
         $postData = $playwrightRequest->postData();
+        if (null === $postData) {
+            $postData = $playwrightRequest->postDataBuffer();
+        }
 
         $parameters = [];
         $cookies = [];

--- a/tests/Client/RequestConverterTest.php
+++ b/tests/Client/RequestConverterTest.php
@@ -65,6 +65,34 @@ class RequestConverterTest extends TestCase
         self::assertSame('text/plain', $file->getClientMimeType());
     }
 
+    public function testMultipartFormDataFallsBackToPostDataBufferWhenPostDataIsNull(): void
+    {
+        $boundary = 'XyZ123456';
+        $body = "--$boundary\r\n".
+            "Content-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n".
+            "--$boundary\r\n".
+            "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n".
+            "Content-Type: text/plain\r\n\r\nHello file!\r\n".
+            "--$boundary--\r\n";
+
+        $converter = new RequestConverter();
+        $request = new MockRequest(
+            url: 'http://localhost/upload',
+            method: 'POST',
+            headers: ['content-type' => 'multipart/form-data; boundary='.$boundary],
+            postData: null,
+            postDataBuffer: $body,
+        );
+
+        $symfony = $converter->convertToSymfonyRequest($request);
+
+        self::assertSame('value', $symfony->request->get('field'));
+        self::assertSame($body, $symfony->getContent());
+        $file = $symfony->files->get('file');
+        self::assertInstanceOf(UploadedFile::class, $file);
+        self::assertSame('test.txt', $file->getClientOriginalName());
+    }
+
     public function testMultipartSupportsArrayFieldsAndUtf8Filenames(): void
     {
         $boundary = 'Boundary123';

--- a/tests/Fixtures/MockRequest.php
+++ b/tests/Fixtures/MockRequest.php
@@ -33,6 +33,7 @@ final readonly class MockRequest implements RequestInterface
         private array $headers = [],
         private ?string $postData = null,
         private string $resourceType = 'document',
+        private ?string $postDataBuffer = null,
     ) {
     }
 
@@ -144,7 +145,7 @@ final readonly class MockRequest implements RequestInterface
 
     public function postDataBuffer(): ?string
     {
-        return $this->postData;
+        return $this->postDataBuffer ?? $this->postData;
     }
 
     public function failure(): ?array


### PR DESCRIPTION
Fixes #3 

## Problem

In-process Playwright intercept passes multipart `FormData` (e.g. Symfony UX Live Component actions) with `postData() === null` while the body is available via `postDataBuffer()`. `RequestConverter` skipped parsing entirely, so the kernel received an empty POST.

## Solution

Fall back to `postDataBuffer()` when `postData()` is null before content-type parsing.

## Tests

- [x] `testMultipartFormDataFallsBackToPostDataBufferWhenPostDataIsNull` added