### PR TITLE
Treat +html structured MIME suffix as text

### DIFF
--- a/src/Client/ResponseConverter.php
+++ b/src/Client/ResponseConverter.php
@@ -162,7 +162,9 @@ class ResponseConverter
             }
         }
 
-        if (str_ends_with($contentType, '+json') || str_ends_with($contentType, '+xml')) {
+        $baseType = trim(explode(';', $contentType, 2)[0]);
+
+        if (str_ends_with($baseType, '+json') || str_ends_with($baseType, '+xml') || str_ends_with($baseType, '+html')) {
             return false;
         }
 

--- a/tests/Client/ResponseConverterTest.php
+++ b/tests/Client/ResponseConverterTest.php
@@ -255,6 +255,25 @@ class ResponseConverterTest extends TestCase
         $this->assertTrue($this->converter->isBinaryContentType('application/vnd.ms-excel'));
     }
 
+    public function testIsBinaryContentTypeTreatsStructuredHtmlSuffixAsText(): void
+    {
+        $this->assertFalse($this->converter->isBinaryContentType('application/vnd.live-component+html'));
+        $this->assertFalse($this->converter->isBinaryContentType('application/vnd.example+html; charset=utf-8'));
+    }
+
+    public function testPrepareFulfillOptionsLeavesLiveComponentHtmlAsPlainText(): void
+    {
+        $html = '<div id="live-1">page 2</div>';
+        $response = new Response($html, 200, [
+            'content-type' => 'application/vnd.live-component+html',
+        ]);
+
+        $opts = $this->converter->prepareFulfillOptions($response);
+
+        $this->assertSame($html, $opts['body']);
+        $this->assertArrayNotHasKey('isBase64', $opts);
+    }
+
     public function testPrepareFulfillOptionsForBinaryResponseWithContentType(): void
     {
         $binaryData = random_bytes(32);


### PR DESCRIPTION
Fixes #5 

## Problem

`application/vnd.live-component+html` (Symfony UX Live Component) was treated as binary. `prepareFulfillOptions()` base64-encoded the HTML body, so morphdom never updated the DOM during in-process Playwright intercept.

## Solution

Extend structured suffix handling (`+json`, `+xml`) to `+html`, matching on the base MIME type before `; charset=…` parameters.

## Tests

- [x] `testIsBinaryContentTypeTreatsStructuredHtmlSuffixAsText` added
- [x] `testPrepareFulfillOptionsLeavesLiveComponentHtmlAsPlainText` added