### PR TITLE
Fix container compilation when bundle is disabled

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,13 @@ playwright:
 
 ## Options
 
+### `enabled`
+
+**Type**: `bool` | **Default**: `true`
+
+When set to `false`, the bundle registers no service and no parameter. Use this to keep the bundle
+in `config/bundles.php` while deactivating it for a specific environment.
+
 ### `intercepted_hosts`
 
 **Type**: `string[]` | **Default**: `['localhost', '127.0.0.1', 'testapp.local']`

--- a/src/DependencyInjection/PlaywrightExtension.php
+++ b/src/DependencyInjection/PlaywrightExtension.php
@@ -31,17 +31,22 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class PlaywrightExtension extends Extension
 {
+    /**
+     * When "playwright.enabled" is false, no service and no parameter is registered:
+     * services.php references playwright.* parameters that are only set below, so
+     * loading it for a disabled bundle would break container compilation.
+     */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
-        $loader->load('services.php');
-
         if (!$config['enabled']) {
             return;
         }
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
+        $loader->load('services.php');
 
         $container->setParameter('playwright.intercepted_hosts', $config['intercepted_hosts']); // @phpstan-ignore argument.type
         $container->setParameter('playwright.debug', $config['debug']); // @phpstan-ignore argument.type

--- a/tests/DependencyInjection/PlaywrightExtensionTest.php
+++ b/tests/DependencyInjection/PlaywrightExtensionTest.php
@@ -72,6 +72,34 @@ class PlaywrightExtensionTest extends TestCase
         $this->assertFalse($this->container->hasParameter('playwright.debug'));
     }
 
+    public function testLoadDisabledRegistersNoService(): void
+    {
+        $this->extension->load([['enabled' => false]], $this->container);
+
+        $this->assertSame([], array_diff($this->container->getServiceIds(), ['service_container']));
+    }
+
+    public function testContainerCompilesWhenDisabled(): void
+    {
+        $this->extension->load([['enabled' => false]], $this->container);
+
+        $this->container->compile();
+
+        $this->assertTrue($this->container->isCompiled());
+    }
+
+    public function testContainerCompilesWhenEnabled(): void
+    {
+        $this->container->setParameter('kernel.project_dir', __DIR__);
+        $this->container->setParameter('kernel.debug', false);
+
+        $this->extension->load([['enabled' => true]], $this->container);
+
+        $this->container->compile();
+
+        $this->assertTrue($this->container->isCompiled());
+    }
+
     public function testGetAlias(): void
     {
         $this->assertEquals('playwright', $this->extension->getAlias());


### PR DESCRIPTION
## Problem

`PlaywrightExtension::load()` loads `config/services.php` before checking the `enabled` flag.
The loaded services reference `playwright.asset_prefixes`, `playwright.asset_public_roots` and
`playwright.asset_dev_no_cache`, which are only set when the bundle is enabled. With
`playwright: { enabled: false }`, container compilation fails with a `ParameterNotFoundException`.

The existing `testLoadDisabled` did not catch this because it never compiled the container.

## Fix

Load `services.php` after the `enabled` check: a disabled bundle registers no service and no
parameter.

## Tests

- Compilation test with `enabled: false` (reproduces the failure before the fix)
- Compilation test with `enabled: true`
- Assertion that a disabled bundle registers no service

Docs: the `enabled` option is now documented in `docs/configuration.md`.
