### PR TITLE
Normalize numeric cookie expires from Playwright

### DIFF
--- a/src/Util/CookieJarSync.php
+++ b/src/Util/CookieJarSync.php
@@ -19,39 +19,68 @@ use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
 
 /**
+ * Copies cookies from a Playwright browser context into a BrowserKit cookie jar.
+ *
  * @author Simon André <smn.andre@gmail.com>
  *
  * @internal
  */
 final class CookieJarSync
 {
+    /**
+     * Seeds the jar with every cookie currently stored in the browser context.
+     */
     public static function fromContext(CookieJar $jar, BrowserContextInterface $context): void
     {
-        foreach ($context->cookies() as $c) {
-            $jar->set(new Cookie(
-                name: (string) $c['name'],
-                value: (string) ($c['value'] ?? ''), // @phpstan-ignore nullCoalesce.offset
-                expires: $c['expires'] ?? null, // @phpstan-ignore nullCoalesce.offset
-                path: (string) ($c['path'] ?? '/'), // @phpstan-ignore nullCoalesce.offset
-                domain: (string) ($c['domain'] ?? ''), // @phpstan-ignore nullCoalesce.offset
-                secure: (bool) ($c['secure'] ?? false), // @phpstan-ignore nullCoalesce.offset
-                httponly: (bool) ($c['httpOnly'] ?? false), // @phpstan-ignore nullCoalesce.offset
-            ));
+        foreach ($context->cookies() as $cookie) {
+            $jar->set(self::toBrowserKitCookie($cookie));
         }
     }
 
+    /**
+     * Seeds the jar with the context cookies that match the given URL.
+     */
     public static function toJarFromUrl(CookieJar $jar, BrowserContextInterface $context, string $url): void
     {
-        foreach ($context->cookies([$url]) as $c) {
-            $jar->set(new Cookie(
-                name: (string) $c['name'],
-                value: (string) ($c['value'] ?? ''), // @phpstan-ignore nullCoalesce.offset
-                expires: $c['expires'] ?? null, // @phpstan-ignore nullCoalesce.offset
-                path: (string) ($c['path'] ?? '/'), // @phpstan-ignore nullCoalesce.offset
-                domain: (string) ($c['domain'] ?? ''), // @phpstan-ignore nullCoalesce.offset
-                secure: (bool) ($c['secure'] ?? false), // @phpstan-ignore nullCoalesce.offset
-                httponly: (bool) ($c['httpOnly'] ?? false), // @phpstan-ignore nullCoalesce.offset
-            ));
+        foreach ($context->cookies([$url]) as $cookie) {
+            $jar->set(self::toBrowserKitCookie($cookie));
         }
+    }
+
+    /**
+     * @param array<string, mixed> $cookie
+     */
+    private static function toBrowserKitCookie(array $cookie): Cookie
+    {
+        return new Cookie(
+            name: self::toString($cookie['name'] ?? ''),
+            value: self::toString($cookie['value'] ?? ''),
+            expires: self::normalizeExpires($cookie['expires'] ?? null),
+            path: self::toString($cookie['path'] ?? '/'),
+            domain: self::toString($cookie['domain'] ?? ''),
+            secure: (bool) ($cookie['secure'] ?? false),
+            httponly: (bool) ($cookie['httpOnly'] ?? false),
+        );
+    }
+
+    /**
+     * Playwright reports "expires" as a number: -1 for session cookies, a Unix
+     * timestamp (possibly float) otherwise. BrowserKit expects string|int|null,
+     * and treats any past timestamp as expired, so negatives must map to null.
+     */
+    private static function normalizeExpires(mixed $expires): ?int
+    {
+        if (!is_numeric($expires)) {
+            return null;
+        }
+
+        $timestamp = (int) $expires;
+
+        return $timestamp < 0 ? null : $timestamp;
+    }
+
+    private static function toString(mixed $value): string
+    {
+        return is_scalar($value) ? (string) $value : '';
     }
 }

--- a/tests/Util/CookieJarSyncTest.php
+++ b/tests/Util/CookieJarSyncTest.php
@@ -41,6 +41,50 @@ final class CookieJarSyncTest extends TestCase
         $this->assertSame('v2', $jar->get('c2', '/app', 'example.com')->getValue());
     }
 
+    public function testFromContextAcceptsNumericExpires(): void
+    {
+        $future = time() + 3600;
+
+        $context = new FakeBrowserContext();
+        $context->addCookies([
+            // Playwright reports "expires" as a number: -1 for session cookies,
+            // a Unix timestamp (possibly float) otherwise.
+            ['name' => 'session', 'value' => 's', 'domain' => 'localhost', 'path' => '/', 'expires' => -1],
+            ['name' => 'float', 'value' => 'f', 'domain' => 'localhost', 'path' => '/', 'expires' => $future + 0.5],
+            ['name' => 'int', 'value' => 'i', 'domain' => 'localhost', 'path' => '/', 'expires' => $future],
+        ]);
+
+        $jar = new CookieJar();
+        CookieJarSync::fromContext($jar, $context);
+
+        $session = $jar->get('session', '/', 'localhost');
+        $this->assertNotNull($session);
+        $this->assertNull($session->getExpiresTime());
+
+        $float = $jar->get('float', '/', 'localhost');
+        $this->assertNotNull($float);
+        $this->assertSame((string) $future, $float->getExpiresTime());
+
+        $int = $jar->get('int', '/', 'localhost');
+        $this->assertNotNull($int);
+        $this->assertSame((string) $future, $int->getExpiresTime());
+    }
+
+    public function testToJarFromUrlAcceptsNumericExpires(): void
+    {
+        $context = new FakeBrowserContext();
+        $context->addCookies([
+            ['name' => 'site', 'value' => 'main', 'domain' => 'localhost', 'path' => '/', 'expires' => -1],
+        ]);
+
+        $jar = new CookieJar();
+        CookieJarSync::toJarFromUrl($jar, $context, 'http://localhost/foo');
+
+        $site = $jar->get('site');
+        $this->assertNotNull($site);
+        $this->assertNull($site->getExpiresTime());
+    }
+
     public function testToJarFromUrlFiltersCookies(): void
     {
         $context = new FakeBrowserContext();


### PR DESCRIPTION
## Problem

Playwright reports cookie `expires` as a number: `-1` for session cookies, a Unix timestamp
(possibly float) otherwise. `CookieJarSync` passed the raw value to BrowserKit's
`Cookie::__construct()`, which accepts `string|int|null`:

- a float value throws a `TypeError` under `strict_types`
- `-1` would be interpreted as "expired in 1969", so session cookies were silently dropped
  from the jar

The path is hit on every `visit()` with a real browser; unit fakes masked it.

## Fix

Normalize `expires` before building the BrowserKit cookie: negative values map to `null`
(session cookie), numeric values are cast to an integer timestamp. The duplicated cookie
construction is extracted into a single helper, removing the `@phpstan-ignore` comments.

## Tests

Cases for `-1`, float and int timestamps, on both `fromContext()` and `toJarFromUrl()`.
