### PR TITLE
Keep multiple Set-Cookie headers separate

### DIFF
--- a/src/Client/ResponseConverter.php
+++ b/src/Client/ResponseConverter.php
@@ -80,7 +80,7 @@ class ResponseConverter
 
         $options = [
             'status' => $response->getStatusCode(),
-            'headers' => $this->stripContentLength($headers),
+            'headers' => $this->flattenForFulfill($this->stripContentLength($headers)),
         ];
 
         if ($contentType) {
@@ -100,16 +100,24 @@ class ResponseConverter
     }
 
     /**
+     * Formats response headers for BrowserKit.
+     *
+     * Multiple values are joined with ", " except Set-Cookie, which is the only
+     * header that cannot be comma-joined (cookie expiry dates contain commas and
+     * each cookie must stay a separate header). Set-Cookie values are kept as a
+     * list, which BrowserKit responses accept as-is.
+     *
      * @param array<string, list<string|null>|string|null> $headers
      *
-     * @return array<string, string>
+     * @return array<string, string|list<string>>
      */
     public function formatHeaders(array $headers): array
     {
         $formatted = [];
         foreach ($headers as $name => $values) {
             if (is_array($values)) {
-                $formatted[$name] = implode(', ', array_filter($values, fn ($v) => null !== $v));
+                $clean = array_values(array_filter($values, static fn (?string $v): bool => null !== $v));
+                $formatted[$name] = 'set-cookie' === strtolower((string) $name) ? $clean : implode(', ', $clean);
             } else {
                 $formatted[$name] = (string) $values;
             }
@@ -119,9 +127,29 @@ class ResponseConverter
     }
 
     /**
-     * @param array<string, string> $headers
+     * Flattens formatted headers into the dict shape expected by route.fulfill().
+     *
+     * Playwright's fulfill headers hold one string per name; the browser driver
+     * splits a "\n"-joined Set-Cookie value back into separate headers.
+     *
+     * @param array<string, string|list<string>> $headers
      *
      * @return array<string, string>
+     */
+    private function flattenForFulfill(array $headers): array
+    {
+        $flattened = [];
+        foreach ($headers as $name => $value) {
+            $flattened[$name] = is_array($value) ? implode("\n", $value) : $value;
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * @param array<string, string|list<string>> $headers
+     *
+     * @return array<string, string|list<string>>
      */
     private function stripContentLength(array $headers): array
     {

--- a/tests/Client/ResponseConverterTest.php
+++ b/tests/Client/ResponseConverterTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Symfony\Client\ResponseConverter;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -212,6 +213,45 @@ class ResponseConverterTest extends TestCase
 
         $this->assertSame('value1, value2', $opts['headers']['x-custom-multi']);
         $this->assertSame('Accept, Accept-Encoding', $opts['headers']['vary']);
+    }
+
+    public function testFormatHeadersKeepsSetCookieValuesSeparate(): void
+    {
+        $headers = [
+            'set-cookie' => [
+                'sid=abc; expires=Wed, 21 Oct 2026 07:28:00 GMT; path=/',
+                'theme=dark; path=/',
+            ],
+            'x-multi' => ['a', 'b'],
+        ];
+
+        $formatted = $this->converter->formatHeaders($headers);
+
+        $this->assertSame(
+            [
+                'sid=abc; expires=Wed, 21 Oct 2026 07:28:00 GMT; path=/',
+                'theme=dark; path=/',
+            ],
+            $formatted['set-cookie'],
+        );
+        $this->assertSame('a, b', $formatted['x-multi']);
+    }
+
+    public function testPrepareFulfillOptionsJoinsSetCookieWithNewline(): void
+    {
+        $response = new Response('', 200);
+        $response->headers->setCookie(Cookie::create('sid', 'abc'));
+        $response->headers->setCookie(Cookie::create('theme', 'dark'));
+
+        $opts = $this->converter->prepareFulfillOptions($response);
+
+        $this->assertIsString($opts['headers']['set-cookie']);
+        // Playwright's fulfill convention: multiple Set-Cookie values are joined
+        // with "\n" and split back into separate headers by the browser driver.
+        $cookies = explode("\n", $opts['headers']['set-cookie']);
+        $this->assertCount(2, $cookies);
+        $this->assertStringStartsWith('sid=abc;', $cookies[0]);
+        $this->assertStringStartsWith('theme=dark;', $cookies[1]);
     }
 
     public function testPrepareFulfillOptionsWithNullContentType(): void


### PR DESCRIPTION
## Problem

`ResponseConverter::formatHeaders()` joins multi-value headers with `", "`. `Set-Cookie` is the
one header where this is invalid: cookie expiry dates contain commas, and two cookies in one
response (session + CSRF, for example) merge into a single broken header.

## Fix

- `formatHeaders()` keeps `Set-Cookie` values as a list (BrowserKit responses accept arrays)
  and still joins other headers with `", "`
- for `route.fulfill()` options, `Set-Cookie` values are joined with `"\n"`, the Playwright
  convention: the browser driver splits them back into separate headers
  (`splitSetCookieHeader` in Playwright's Chromium network manager)

## Tests

- `formatHeaders()` keeps two cookies separate
- fulfill options carry both cookies joined with `"\n"`
