### PR TITLE
Make popup following opt-in and timeout-safe

### DIFF
--- a/docs/bridge/browserkit.md
+++ b/docs/bridge/browserkit.md
@@ -43,8 +43,16 @@ $crawler = $client->submit($form);
 
 ## Options
 
-- `followPopups`: when a click opens a new tab, the client switches to it (Panther-like). You can turn it off if you
-  prefer single-tab only.
+- `setFollowPopups(bool)`: disabled by default. When enabled, a click or submit that opens a new
+  tab makes the client switch to it (Panther-like). Enabling it makes every click() and submit()
+  wait for a potential popup before returning, so actions that do not open one pay the popup
+  timeout: enable it only around interactions expected to open a new tab.
+
+```php
+$client->setFollowPopups(true);
+$client->click($crawler->selectLink('Open preview')->link());
+$client->setFollowPopups(false);
+```
 
 ## Container integration
 

--- a/src/BrowserKit/PlaywrightClient.php
+++ b/src/BrowserKit/PlaywrightClient.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Playwright\Symfony\BrowserKit;
 
 use Playwright\Browser\BrowserContextInterface;
+use Playwright\Exception\TimeoutException;
 use Playwright\Page\PageInterface;
 use Playwright\Symfony\Util\CookieJarSync;
 use Playwright\Symfony\Util\FormInteractor;
@@ -56,7 +57,7 @@ use Symfony\Component\DomCrawler\Link;
  *
  * Features:
  * - Real browser semantics: click(), submit() use Playwright actions (not synthetic HTTP)
- * - Handles popups: automatically switches to new tabs when links open them
+ * - Popup support: opt-in via setFollowPopups(true), switches to new tabs when links open them
  * - Form handling: creates synthetic forms in-page to preserve browser events
  * - Cookie sync: keeps BrowserKit CookieJar in sync with Playwright context
  * - Server params: maps HTTP_* headers and PHP_AUTH_* credentials to Playwright
@@ -98,7 +99,7 @@ final class PlaywrightClient extends AbstractBrowser
 
     private ?BrowserKitResponse $lastResponse = null;
 
-    private bool $followPopups = true;
+    private bool $followPopups = false;
 
     /**
      * @param array<string, mixed> $server
@@ -133,6 +134,19 @@ final class PlaywrightClient extends AbstractBrowser
     public function getPage(): PageInterface
     {
         return $this->page;
+    }
+
+    /**
+     * Enables or disables following popups opened by click() and submit().
+     *
+     * When enabled, an action that opens a new tab makes the client switch to
+     * it (Panther-like). Every action then waits for a potential popup before
+     * returning, which adds the popup timeout to actions that do not open one:
+     * enable it only for interactions expected to open a new tab.
+     */
+    public function setFollowPopups(bool $followPopups): void
+    {
+        $this->followPopups = $followPopups;
     }
 
     public function getLastResponse(): ?BrowserKitResponse
@@ -316,10 +330,13 @@ JS,
             return;
         }
 
-        $popup = $this->page->context()->waitForPopup(function () use ($action): void {
-            $action();
-        });
-        $this->page = $popup;
+        try {
+            $this->page = $this->page->context()->waitForPopup(static function () use ($action): void {
+                $action();
+            });
+        } catch (TimeoutException) {
+            // The action ran but no popup opened: stay on the current page.
+        }
     }
 
     private function applyServerParams(Request $request): void

--- a/tests/BrowserKit/PlaywrightClientTest.php
+++ b/tests/BrowserKit/PlaywrightClientTest.php
@@ -17,9 +17,14 @@ namespace Playwright\Symfony\Tests\BrowserKit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Playwright\Exception\TimeoutException;
+use Playwright\Page\PageInterface;
 use Playwright\Symfony\BrowserKit\PlaywrightClient;
 use Playwright\Symfony\Tests\Client\Fixtures\FakeBrowserContext;
+use Playwright\Symfony\Tests\Client\Fixtures\FakePage;
 use Playwright\Symfony\Util\CookieJarSync;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Link;
 
 #[CoversClass(PlaywrightClient::class)]
 #[UsesClass(CookieJarSync::class)]
@@ -220,6 +225,69 @@ final class PlaywrightClientTest extends TestCase
 
         self::assertNotNull($response);
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testClickDoesNotWaitForPopupByDefault(): void
+    {
+        $context = new FakeBrowserContext();
+        $client = PlaywrightClient::fromContext($context);
+        $client->request('GET', 'http://example.test/');
+        $pageBeforeClick = $client->getPage();
+        self::assertInstanceOf(FakePage::class, $pageBeforeClick);
+
+        $client->click($this->createLink());
+
+        self::assertSame(0, $context->waitForPopupCalls);
+        self::assertSame($pageBeforeClick, $client->getPage());
+        self::assertContains('click', array_column($pageBeforeClick->locatorCalls, 'method'));
+    }
+
+    public function testClickFollowsPopupWhenEnabled(): void
+    {
+        $context = new FakeBrowserContext();
+        $client = PlaywrightClient::fromContext($context);
+        $client->setFollowPopups(true);
+        $client->request('GET', 'http://example.test/');
+        $pageBeforeClick = $client->getPage();
+        self::assertInstanceOf(FakePage::class, $pageBeforeClick);
+
+        $client->click($this->createLink());
+
+        self::assertSame(1, $context->waitForPopupCalls);
+        self::assertNotSame($pageBeforeClick, $client->getPage());
+        self::assertContains('click', array_column($pageBeforeClick->locatorCalls, 'method'));
+    }
+
+    public function testClickStaysOnPageWhenNoPopupOpens(): void
+    {
+        $context = new class extends FakeBrowserContext {
+            public function waitForPopup(callable $action, array $options = []): PageInterface
+            {
+                $action();
+
+                throw new TimeoutException('No popup was created within the timeout period');
+            }
+        };
+        $client = PlaywrightClient::fromContext($context);
+        $client->setFollowPopups(true);
+        $client->request('GET', 'http://example.test/');
+        $pageBeforeClick = $client->getPage();
+        self::assertInstanceOf(FakePage::class, $pageBeforeClick);
+
+        $client->click($this->createLink());
+
+        self::assertSame($pageBeforeClick, $client->getPage());
+        self::assertContains('click', array_column($pageBeforeClick->locatorCalls, 'method'));
+    }
+
+    private function createLink(): Link
+    {
+        $crawler = new Crawler(
+            '<html><body><a id="next-link" href="/next">Next</a></body></html>',
+            'http://example.test/',
+        );
+
+        return $crawler->filter('#next-link')->link();
     }
 
     public function testApplyServerParamsWithHttpHeaders(): void

--- a/tests/Client/Fixtures/FakeBrowserContext.php
+++ b/tests/Client/Fixtures/FakeBrowserContext.php
@@ -26,6 +26,7 @@ class FakeBrowserContext implements BrowserContextInterface
     public array $cookies = [];
     public array $extraHTTPHeaders = [];
     public ?array $httpCredentials = null;
+    public int $waitForPopupCalls = 0;
     /** @var array<int, PageInterface> */
     private array $pages = [];
     private ?string $envValue = null;
@@ -164,6 +165,9 @@ class FakeBrowserContext implements BrowserContextInterface
 
     public function waitForPopup(callable $action, array $options = []): PageInterface
     {
+        ++$this->waitForPopupCalls;
+        $action();
+
         return $this->newPage();
     }
 


### PR DESCRIPTION
## Problem

Every `click()` and `submit()` of `BrowserKit\PlaywrightClient` went through
`context->waitForPopup()`, which throws a `TimeoutException` after 30s when no popup opens.
A click on a regular link therefore blocked for 30 seconds and failed. `followPopups` was a
private property, always `true`, with no setter, although the docs presented it as an option.

Unit tests did not catch this: the fake `waitForPopup()` returned a page without even executing
the action, so the click tests passed without any click being simulated.

## Fix

- popup following is now opt-in via `setFollowPopups(bool)`, disabled by default
- when enabled and no popup opens, `TimeoutException` is caught and the client stays on the
  current page
- the fake now executes the action and counts `waitForPopup` calls

## Tests

- default click does not wait for a popup and stays on the page
- enabled mode switches to the popup page
- enabled mode survives the no-popup timeout

Docs: `docs/bridge/browserkit.md` describes the new default and the timeout trade-off.
