### PR TITLE
Fix factual errors in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **E2E testing for Symfony with real browsers and in-process request handling.**
 
-Run Playwright browser tests while intercepting HTTP requests and routing them through your Symfony kernel in the same PHP process—giving you full access to services, the profiler, and application state.
+Run Playwright browser tests while intercepting HTTP requests and routing them through your Symfony kernel in the same PHP process, giving you full access to services, the profiler, and application state.
 
 > [!IMPORTANT]
 > **Alpha Status**
@@ -151,12 +151,12 @@ PLAYWRIGHT_E2E=1 PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit tests/E2E
 
 ## Usage Notes
 
-- `PlaywrightTestCase` drives a real browser. Calling `request()` (the traditional BrowserKit API) on the underlying client will throw—always navigate with `visit()`/Playwright APIs instead. If you need classic BrowserKit semantics, autowire [`Playwright\Symfony\BrowserKit\PlaywrightClient`](docs/bridge/browserkit.md) from the container; it reuses the bundle’s Playwright context.
+- `PlaywrightTestCase` drives a real browser. Calling `request()` (the traditional BrowserKit API) on the underlying client performs a plain GET navigation: POST requests, parameters and request bodies are not routed through the kernel yet. Always prefer `visit()` and the Playwright Page API. If you need classic BrowserKit semantics against real HTTP, use [`Playwright\Symfony\BrowserKit\PlaywrightClient`](docs/bridge/browserkit.md) from the container; it reuses the bundle's Playwright context.
 - Set `PLAYWRIGHT_BASE_URL` (or the `playwright.base_url` config) to match the hostnames you intercept; this also controls which cookies are set when calling helper methods like `authenticate()`.
 
 ## Asset Dev Server
 
-Static files (including AssetMapper output) are served by the in-process `AssetServer`, so requests under `/assets`, `/build`, and other configured prefixes never touch the kernel. Customize prefixes, additional `public_roots`, and cache behavior via `playwright.assets`—see [`docs/ASSET_DEV_SERVER.md`](docs/asset-dev-server.md) for a full walkthrough and troubleshooting tips.
+Static files (including AssetMapper output) are served by the in-process `AssetServer`, so requests under `/assets`, `/build`, and other configured prefixes never touch the kernel. Customize prefixes, additional `public_roots`, and cache behavior via `playwright.assets`: see [`docs/asset-dev-server.md`](docs/asset-dev-server.md) for a full walkthrough and troubleshooting tips.
 
 ## Common Scenarios
 
@@ -370,7 +370,7 @@ jobs:
           php-version: '8.3'
 
       - run: composer install
-      - run: npx playwright install chromium --with-deps
+      - run: vendor/bin/playwright-install --with-deps
 
       - name: Run E2E tests
         run: vendor/bin/phpunit tests/E2E
@@ -407,7 +407,7 @@ jobs:
 
 - PHP 8.3+
 - Symfony 7.0+ or 8.0+
-- Node.js 18+
+- Node.js 20+
 - Playwright browsers
 
 ## Contributing

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -68,13 +68,31 @@ playwright:
       headless: false
 ```
 
-In your test:
+Each named browser is exposed as a named autowiring alias for `BrowserContextInterface`. Inject it
+in any autowired service by naming the constructor argument after the browser (camelCase):
 
 ```php
-public function testWithFirefox(\Playwright\Browser\BrowserContextInterface $firefoxDebug): void
+// src/Testing/FirefoxSmokeChecker.php
+use Playwright\Browser\BrowserContextInterface;
+
+final class FirefoxSmokeChecker
 {
-    $page = $firefoxDebug->newPage();
-    $page->goto('http://localhost/');
-    // ...
+    public function __construct(
+        private BrowserContextInterface $firefoxDebug,
+    ) {
+    }
+
+    public function check(string $url): string
+    {
+        $page = $this->firefoxDebug->newPage();
+        $page->goto($url);
+
+        return $page->title();
+    }
 }
 ```
+
+> **Note**
+> PHPUnit does not autowire test method arguments: type-hinted parameters on a test method are
+> treated as data provider values, not services. Inject named browsers into services, not into
+> test methods.

--- a/docs/bridge/browserkit.md
+++ b/docs/bridge/browserkit.md
@@ -19,8 +19,7 @@ snapshots after each action.
 use Playwright\Symfony\BrowserKit\PlaywrightClient;
 use Playwright\Playwright;
 
-$pw = Playwright::chromium()->launch();
-$context = $pw->newContext();
+$context = Playwright::chromium();
 
 $client = PlaywrightClient::fromContext($context);
 
@@ -65,4 +64,3 @@ without manual wiring.
 
 - Track last main-frame navigation Response reliably via a small network tracker on Page.
 - Add a PHPUnit trait for automatic artifacts (screenshot, HTML) on failure.
-- Provide a Symfony Bundle for DI/autowiring in test env.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -5,7 +5,7 @@ official action to set up the environment.
 
 ## GitHub Actions
 
-The easiest way to set up Playwright in your GitHub workflows is by using the `playwright-php/setup-playwright-php`
+The easiest way to set up Playwright in your GitHub workflows is by using the `playwright-php/setup-playwright`
 action.
 
 ```yaml
@@ -28,7 +28,7 @@ jobs:
         run: composer install --prefer-dist
 
       - name: Setup Playwright PHP
-        uses: playwright-php/setup-playwright-php@v1
+        uses: playwright-php/setup-playwright@v1
         with:
           browsers: chromium # Optional: chromium, firefox, webkit (default: all)
 

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -361,8 +361,8 @@ $context->addCookies(array $cookies);
 // Get cookies
 $cookies = $context->cookies(?array $urls = null);
 
-// Delete cookie
-$context->deleteCookie(string $name, string $domain, string $path);
+// Delete all cookies with the given name (across domain and path variants)
+$context->deleteCookie(string $name);
 
 // Clear all
 $context->clearCookies();
@@ -381,8 +381,7 @@ $context->clearCookies();
 
 ## See Also
 
-- [Cookie Fix Investigation](troubleshooting/cookie-fix-investigation.md) - Detailed debugging process
-- [Testing Guide](testing.md) - General testing documentation
+- [Helper & Assertion Reference](helpers.md) - Cookie helper methods on `PlaywrightTestCase`
 - [Playwright Cookie API](https://playwright.dev/docs/api/class-browsercontext#browser-context-add-cookies) - Upstream
   documentation
 

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -389,20 +389,23 @@ public function testAdminWorkflow(): void
 
 ### Custom Authentication
 
-If you need more control over authentication, override `beforeRequest()`:
+If you need more control over authentication, override `beforeRequest()`. The method must stay
+`public` (it is declared `public` in `PlaywrightTestCase`):
 
 ```php
-protected function beforeRequest(SymfonyRequest $request): void
+public function beforeRequest(SymfonyRequest $request): void
 {
-    // Set up session data
-    $session = $request->getSession();
-    $session->set('user_id', 123);
-    $session->set('roles', ['ROLE_USER']);
-
-    // Or modify headers
+    // Modify headers before the kernel handles the request
     $request->headers->set('Authorization', 'Bearer token123');
+
+    // Or add cookies the firewall can read
+    $request->cookies->set('AUTH', 'admin-token');
 }
 ```
+
+> **Note**
+> The request has no session at this stage: the session is started later by the kernel while
+> handling the request. Calling `$request->getSession()` here throws `SessionNotFoundException`.
 
 ## Request/Response Introspection
 
@@ -474,24 +477,19 @@ Override this method to customize requests before they reach the kernel.
 **Use Cases:**
 
 - Modify request headers
-- Set session data
 - Add authentication tokens
 - Change locale
 
 **Example:**
 
 ```php
-protected function beforeRequest(SymfonyRequest $request): void
+public function beforeRequest(SymfonyRequest $request): void
 {
     // Add custom header to all requests
     $request->headers->set('X-Test-Mode', 'true');
 
     // Set locale
     $request->setLocale('fr');
-
-    // Add authentication
-    $session = $request->getSession();
-    $session->set('user_id', 123);
 }
 ```
 
@@ -511,7 +509,7 @@ Override this method to inspect or modify responses after the kernel returns the
 **Example:**
 
 ```php
-protected function afterResponse(SymfonyResponse $response): void
+public function afterResponse(SymfonyResponse $response): void
 {
     // Assert all responses have security headers
     $this->assertTrue($response->headers->has('X-Frame-Options'));
@@ -637,13 +635,13 @@ class OrderFlowTest extends PlaywrightTestCase
         $em->flush();
     }
 
-    protected function beforeRequest(SymfonyRequest $request): void
+    public function beforeRequest(SymfonyRequest $request): void
     {
         // Add test header to all requests
         $request->headers->set('X-Test-Run', 'e2e');
     }
 
-    protected function afterResponse(SymfonyResponse $response): void
+    public function afterResponse(SymfonyResponse $response): void
     {
         // Ensure no errors in responses
         $this->assertLessThan(400, $response->getStatusCode());

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,7 +66,7 @@ These check the response returned by the Symfony Kernel during the last intercep
 You can take screenshots at any point during your test:
 
 ```php
-$this->page->screenshot(['path' => 'var/screenshots/test.png']);
+$this->page->screenshot('var/screenshots/test.png');
 ```
 
 Or use the helper:


### PR DESCRIPTION
Documentation-only fixes, each verified against the code:

- README: `request()` does not throw (it performs a GET navigation, other methods are not
  routed through the kernel yet); Node.js requirement unified to 20+; CI example uses
  `vendor/bin/playwright-install --with-deps`; link text matched to `docs/asset-dev-server.md`
- `helpers.md`: `beforeRequest()`/`afterResponse()` are `public` in `PlaywrightTestCase`, the
  `protected` overrides shown produced a fatal error; the `getSession()` example threw
  `SessionNotFoundException` (no session at that stage) and is replaced
- `usage.md`: `screenshot()` takes a string path, not an options array
- `advanced.md`: PHPUnit does not autowire test method arguments; named browsers are now shown
  injected into a service constructor
- `cookies.md`: `deleteCookie()` takes only a name; two broken links removed
- `ci.md`: the GitHub action slug is `playwright-php/setup-playwright`, not
  `setup-playwright-php`
- `bridge/browserkit.md`: the usage example called a non-existent API
  (`Playwright::chromium()->launch()` then `newContext()`); stale roadmap entry removed
