### PR TITLE
Populate REMOTE_ADDR on synthetic requests

### DIFF
--- a/src/Client/RequestConverter.php
+++ b/src/Client/RequestConverter.php
@@ -45,6 +45,7 @@ class RequestConverter
         $cookies = [];
         $files = [];
         $server = [
+            'REMOTE_ADDR' => '127.0.0.1',
             'REQUEST_METHOD' => $method,
             'REQUEST_URI' => ($url['path'] ?? '/').(isset($url['query']) ? '?'.$url['query'] : ''),
             'SERVER_NAME' => $url['host'] ?? 'localhost',

--- a/tests/Client/RequestConverterTest.php
+++ b/tests/Client/RequestConverterTest.php
@@ -319,4 +319,14 @@ class RequestConverterTest extends TestCase
         self::assertSame('localhost', $symfony->server->get('SERVER_NAME'));
         self::assertSame('not-a-valid-url', $symfony->server->get('REQUEST_URI'));
     }
+
+    public function testPopulatesRemoteAddr(): void
+    {
+        $converter = new RequestConverter();
+        $request = new MockRequest(url: 'http://localhost/', method: 'GET');
+
+        $symfony = $converter->convertToSymfonyRequest($request);
+
+        self::assertSame('127.0.0.1', $symfony->getClientIp());
+    }
 }


### PR DESCRIPTION
Fixes #21.

## Problem

`RequestConverter::convertToSymfonyRequest()` builds the `$server` array without a `REMOTE_ADDR` key, so `$request->getClientIp()` returns `null` on synthetic requests. Symfony's `DefaultLoginRateLimiter::getLimiters()` calls `$this->hash($request->getClientIp())`, and `hash()` is typed `string`, so a `null` client IP throws a `TypeError` — breaking any form-login test that goes through the login rate limiter.

## Fix

Default `REMOTE_ADDR` to `127.0.0.1` so synthetic requests carry a valid client IP, mirroring the default Symfony's own `Request::create()` factory uses.

Kept minimal and hardcoded (no env/config surface): the value's only job is to be a valid, non-null loopback IP, and a single global value can't simulate the multi-IP scenarios where configurability would actually matter.

## Test

Added `testPopulatesRemoteAddr` asserting `getClientIp()` resolves to `127.0.0.1` — the end-to-end regression guard for the `TypeError`.

Full suite green, php-cs-fixer and phpstan clean.