### PR TITLE
Append repeated `name[]` fields when parsing multipart bodies

### DIFF
--- a/src/Client/RequestConverter.php
+++ b/src/Client/RequestConverter.php
@@ -305,7 +305,15 @@ class RequestConverter
             $ref = &$ref[$segment];
         }
 
-        if ('' === $last || ctype_digit($last)) {
+        // "name[]" appends: assigning (int) '' === 0 would make every repeated part
+        // overwrite the first one, keeping only the last value.
+        if ('' === $last) {
+            $ref[] = $value;
+
+            return;
+        }
+
+        if (ctype_digit($last)) {
             $last = (int) $last;
         }
         $ref[$last] = $value;

--- a/tests/Client/RequestConverterTest.php
+++ b/tests/Client/RequestConverterTest.php
@@ -127,6 +127,40 @@ class RequestConverterTest extends TestCase
         self::assertSame(rtrim($binary, "\r\n"), file_get_contents($file->getRealPath()));
     }
 
+    public function testMultipartAppendsRepeatedArrayFields(): void
+    {
+        $boundary = 'Boundary123';
+        $body = "--$boundary\r\n".
+            "Content-Disposition: form-data; name=\"choices[]\"\r\n\r\none\r\n".
+            "--$boundary\r\n".
+            "Content-Disposition: form-data; name=\"choices[]\"\r\n\r\nthree\r\n".
+            "--$boundary\r\n".
+            "Content-Disposition: form-data; name=\"uploads[]\"; filename=\"a.txt\"\r\n".
+            "Content-Type: text/plain\r\n\r\naaa\r\n".
+            "--$boundary\r\n".
+            "Content-Disposition: form-data; name=\"uploads[]\"; filename=\"b.txt\"\r\n".
+            "Content-Type: text/plain\r\n\r\nbbb\r\n".
+            "--$boundary--\r\n";
+
+        $converter = new RequestConverter();
+        $request = new MockRequest(
+            url: 'http://localhost/submit',
+            method: 'POST',
+            headers: ['content-type' => 'multipart/form-data; boundary='.$boundary],
+            postData: $body,
+        );
+
+        $symfony = $converter->convertToSymfonyRequest($request);
+
+        self::assertSame(['one', 'three'], $symfony->request->all('choices'));
+
+        $uploads = $symfony->files->get('uploads');
+        self::assertIsArray($uploads);
+        self::assertCount(2, $uploads);
+        self::assertSame('a.txt', $uploads[0]->getClientOriginalName());
+        self::assertSame('b.txt', $uploads[1]->getClientOriginalName());
+    }
+
     public function testConvertsHttpMethods(): void
     {
         $converter = new RequestConverter();


### PR DESCRIPTION
`RequestConverter::setArrayByPath()` treats a trailing empty bracket as index `0` (`(int) '' === 0`), so every repeated `name[]` part overwrites the previous one and only the last value survives. A form with `<select name="choices[]" multiple>` and two selections arrives at the kernel as a single-element array, and a `multiple` file input keeps only the last upload.

Only multipart bodies are affected — the `application/x-www-form-urlencoded` branch delegates to `parse_str()`, which handles this correctly. Because `createUploadedFile()` shares the same helper, the fix covers both scalar fields and uploads.

The existing `testMultipartSupportsArrayFieldsAndUtf8Filenames()` passes today because it sends exactly one `attachments[]` part, where writing to index `0` happens to be right; the bug needs two or more parts to show up. Added a regression test with two repeated scalar fields and two repeated file fields.

Found while building a Playwright backend for `zenstruck/browser` on top of this bundle: five form-submission tests failed because the browser's native multipart submission lost values.
