### PR TITLE
Emit kernel redirects client-side so navigations stay intercepted

### DIFF
--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -461,7 +461,7 @@ class PlaywrightKernelClient extends AbstractBrowser
 
             $response = $this->handleInternalRequest($request);
             if (method_exists($route, 'fulfill')) {
-                $route->fulfill($this->responseConverter->prepareFulfillOptions($response));
+                $route->fulfill($this->responseConverter->prepareFulfillOptions($response, 'document' === $request->resourceType()));
             }
         });
     }

--- a/src/Client/ResponseConverter.php
+++ b/src/Client/ResponseConverter.php
@@ -32,9 +32,12 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class ResponseConverter
 {
     /**
+     * @param bool $isNavigation Whether the intercepted request was a navigation, in which case
+     *                           redirects are emitted client-side {@see self::rewriteRedirect()}
+     *
      * @return array<string, mixed>
      */
-    public function prepareFulfillOptions(SymfonyResponse $response): array
+    public function prepareFulfillOptions(SymfonyResponse $response, bool $isNavigation = false): array
     {
         $headers = $this->formatHeaders($response->headers->all());
         $contentType = $response->headers->get('content-type') ?: null;
@@ -96,7 +99,51 @@ class ResponseConverter
             }
         }
 
+        if ($isNavigation) {
+            $options = $this->rewriteRedirect($response, $options);
+        }
+
         return $options;
+    }
+
+    /**
+     * Playwright does not route the follow-up request of a redirect that an interceptor fulfilled:
+     * the browser leaves interception and hits the network instead (ERR_CONNECTION_REFUSED against
+     * a kernel that isn't listening on a port). Emit the redirect client-side so the browser makes
+     * a fresh navigation which does go through routing again - and so page.url() ends up on the
+     * target rather than on the redirecting url.
+     *
+     * 307/308 are deliberately left alone: they must preserve the request method, which
+     * location.replace() cannot do.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function rewriteRedirect(SymfonyResponse $response, array $options): array
+    {
+        if (!in_array($response->getStatusCode(), [301, 302, 303], true)) {
+            return $options;
+        }
+
+        $location = $response->headers->get('location');
+
+        if (null === $location || '' === $location) {
+            return $options;
+        }
+
+        $headers = is_array($options['headers'] ?? null) ? $options['headers'] : [];
+        unset($headers['location'], $headers['Location']);
+
+        return [
+            'status' => 200,
+            'headers' => $headers,
+            'contentType' => 'text/html; charset=UTF-8',
+            'body' => sprintf(
+                '<!DOCTYPE html><script>location.replace(%s)</script>',
+                json_encode($location, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+            ),
+        ];
     }
 
     /**

--- a/tests/Client/ResponseConverterTest.php
+++ b/tests/Client/ResponseConverterTest.php
@@ -32,6 +32,46 @@ class ResponseConverterTest extends TestCase
         $this->converter = new ResponseConverter();
     }
 
+    public function testNavigationRedirectIsEmittedClientSide(): void
+    {
+        $response = new Response('', 302, [
+            'location' => '/target?a=b',
+            'set-cookie' => 'SESSID=abc; path=/',
+        ]);
+
+        $opts = $this->converter->prepareFulfillOptions($response, true);
+
+        $this->assertSame(200, $opts['status']);
+        $this->assertSame('text/html; charset=UTF-8', $opts['contentType']);
+        $this->assertStringContainsString('location.replace("/target?a=b")', $opts['body']);
+        $this->assertArrayNotHasKey('location', $opts['headers']);
+        // cookies set alongside the redirect must survive
+        $this->assertArrayHasKey('set-cookie', $opts['headers']);
+    }
+
+    public function testSubresourceRedirectIsLeftAlone(): void
+    {
+        $response = new Response('', 302, ['location' => '/target']);
+
+        $opts = $this->converter->prepareFulfillOptions($response);
+
+        $this->assertSame(302, $opts['status']);
+        $this->assertSame('/target', $opts['headers']['location']);
+    }
+
+    public function testMethodPreservingRedirectsAreLeftAlone(): void
+    {
+        foreach ([307, 308] as $status) {
+            $opts = $this->converter->prepareFulfillOptions(
+                new Response('', $status, ['location' => '/target']),
+                true,
+            );
+
+            $this->assertSame($status, $opts['status']);
+            $this->assertSame('/target', $opts['headers']['location']);
+        }
+    }
+
     public function testPrepareFulfillOptionsForTextResponse(): void
     {
         $response = new Response('hello', 200, [


### PR DESCRIPTION
Any kernel response with a `3xx` status currently breaks the browser out of interception. Playwright does not route the follow-up request of a redirect that an interceptor fulfilled, so the browser tries to reach the network directly and fails with `net::ERR_CONNECTION_REFUSED` — there is no server listening on the port, by design.

This is Playwright's own behaviour, not a PHP-side issue: I reproduced it in Playwright JS with a plain `page.route()` + `route.fulfill({status: 302, headers: {Location: ...}})` and got the identical failure, with the handler firing only once.

Fix: for document requests, translate `301`/`302`/`303` into a `200` HTML response that performs `location.replace(<target>)`. The browser then makes a fresh navigation that does go through routing, and `page.url()` correctly ends up on the redirect target.

Details worth reviewing:

- Restricted to `resourceType() === 'document'`, so a `3xx` on a stylesheet or image is not replaced with an HTML body. I deliberately did not use `Request::isNavigationRequest()` — it always returns `false` because the server payload omits the field (separate PR against `playwright`) — so this fix works against released `playwright` as-is.
- `Set-Cookie` is preserved and only `Location` is dropped, otherwise a session cookie set alongside a redirect would be lost.
- `307`/`308` are left untouched: they must preserve the request method, which `location.replace()` cannot do.
- Following redirects kernel-side instead would leave `page.url()` on the redirecting URL, so the browser has to make the navigation itself.

Added tests for the navigation rewrite, the subresource case, and the `307`/`308` passthrough.
