### PR TITLE
Add loginUser and extend WebTestCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Before 1.0, breaking changes are released in minor versions.
+
+## [Unreleased]
+
+### Added
+
+- Add `PlaywrightTestCase::loginUser()` with the same signature and firewall token semantics as Symfony's `KernelBrowser::loginUser()`.
+- Make Symfony's `WebTestCase` response, route, session, and DomCrawler assertions available to Playwright tests.
+
+### Changed
+
+- **BC break:** `PlaywrightTestCase` now extends `WebTestCase` instead of `KernelTestCase`. Subclasses that define members inherited from `WebTestCase`, such as `createClient()`, must use compatible signatures.
+- **BC break:** `PlaywrightTestCase::logout()` now accepts an optional firewall context and returns `static` instead of `void`. Overrides must change their signature to `logout(string $firewallContext = 'main'): static`.
+- **BC break:** `assertSelectorExists()`, `assertSelectorNotExists()`, `assertSelectorTextContains()`, and `assertResponseIsSuccessful()` now use the public static Symfony `WebTestCase` signatures. Overrides of the previous protected instance methods must be updated. Calls from tests remain compatible.
+- `logout()` now clears the legacy `AUTH` cookie, Symfony token storage, the selected firewall token in the session, and the browser session cookie.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ composer require --dev playwright-php/playwright-symfony
 - Symfony 7.0+ or 8.0+
 - Node.js 20+ (for Playwright browser communication)
 
+Authentication through a real Symfony firewall is optional. The rest of the package works without SecurityBundle.
+Calling `loginUser()` without it throws a `LogicException` containing the installation command:
+
+```bash
+composer require symfony/security-bundle
+```
+
 **Install Playwright:**
 
 The bundle includes a helper to set up the Playwright environment and download browsers:
@@ -151,6 +158,9 @@ PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit tests/E2E
 
 ## Usage Notes
 
+- `PlaywrightTestCase` extends Symfony's `WebTestCase`. Its intercepted client is registered with the inherited
+  assertion layer, so helpers such as `assertResponseIsSuccessful()`, `assertRouteSame()`, and
+  `assertSelectorExists()` work against the latest intercepted request, response, and browser page.
 - `PlaywrightTestCase` drives a real browser. Calling `request()` (the traditional BrowserKit API) on the underlying client performs a plain GET navigation: POST requests, parameters and request bodies are not routed through the kernel yet. Always prefer `visit()` and the Playwright Page API. If you need classic BrowserKit semantics against real HTTP, use [`Playwright\Symfony\BrowserKit\PlaywrightClient`](docs/bridge/browserkit.md) from the container; it reuses the bundle's Playwright context.
 - Set `PLAYWRIGHT_BASE_URL` (or the `playwright.base_url` config) to match the hostnames you intercept; this also controls which cookies are set when calling helper methods like `authenticate()`.
 
@@ -163,10 +173,16 @@ Static files (including AssetMapper output) are served by the in-process `AssetS
 ### Authentication & Cookies
 
 ```php
+use App\Repository\UserRepository;
+
 public function testAdminAccess(): void
 {
-    // Set authentication cookie
-    $this->authenticate('admin@example.com', ['roles' => ['ROLE_ADMIN']]);
+    $user = static::getContainer()
+        ->get(UserRepository::class)
+        ->findOneBy(['email' => 'admin@example.com']);
+    self::assertNotNull($user);
+
+    $this->loginUser($user);
 
     $page = $this->visit('/admin');
     $this->assertPageContains('Admin Dashboard');
@@ -235,7 +251,9 @@ The bundle provides many helpers for common testing scenarios:
 | Helper | Purpose |
 |--------|---------|
 | `visit($path)` | Navigate to a path and return the Playwright Page |
-| `authenticate($user, $context)` | Set authentication cookie |
+| `loginUser($user, $firewallContext, $tokenAttributes)` | Authenticate with Symfony's real firewall |
+| `authenticate($identifier, $context)` | Set the legacy custom `AUTH` cookie |
+| `logout($firewallContext)` | Clear custom and Symfony firewall authentication |
 | `setCookie($name, $value)` | Set a cookie in the browser |
 | `getLastRequest()` | Access the intercepted Symfony Request |
 | `getLastResponse()` | Access the intercepted Symfony Response |

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,25 +2,44 @@
 
 ## Authentication
 
-The `PlaywrightClient` provides a simple way to authenticate users in your tests.
+`PlaywrightTestCase::loginUser()` uses Symfony's real firewall and matches the signature of
+`KernelBrowser::loginUser()`. SecurityBundle is optional for the package, but must be installed and enabled before
+calling this helper. Otherwise, `loginUser()` throws a `LogicException` with the command to install it:
 
-### Using the Helper
+```bash
+composer require symfony/security-bundle
+```
+
+### Using the Symfony Firewall
 
 ```php
+use App\Repository\UserRepository;
+
 public function testAuthenticatedPage(): void
 {
-    // Authenticates the user (sets an AUTH cookie)
-    $this->authenticate('user@example.com', ['roles' => ['ROLE_ADMIN']]);
+    $user = static::getContainer()
+        ->get(UserRepository::class)
+        ->findOneBy(['email' => 'user@example.com']);
+    self::assertNotNull($user);
+
+    $this->loginUser($user);
 
     $this->visit('/admin');
-    $this->assertResponseIsSuccessful();
+    self::assertResponseIsSuccessful();
 }
 ```
+
+For session-backed firewalls, the user must be serializable. The security token and session cookie are synchronized
+with the intercepted browser request. If sessions are unavailable, the token remains in Symfony's untracked token
+storage and no session cookie is created, matching the standard Symfony test client.
+
+The older `authenticate()` helper remains available for applications that deliberately consume its custom JSON
+`AUTH` cookie. It does not authenticate against Symfony Security by itself.
 
 ### Logging Out
 
 ```php
-$this->logout();
+$this->logout('main');
 $this->visit('/admin');
 $this->assertResponseStatusCode(403);
 ```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -310,6 +310,41 @@ public function testClearAllCookies(): void
 }
 ```
 
+### `loginUser(UserInterface $user, string $firewallContext = 'main', array $tokenAttributes = []): static`
+
+Authenticate a Symfony user through the application's real firewall. The signature and no-session behavior match
+Symfony's `KernelBrowser::loginUser()`: the token is always written to the untracked token storage; when sessions are
+available it is also serialized under `_security_<firewallContext>` and the session cookie is synchronized with the
+browser.
+
+SecurityBundle is optional for the package. Calling this helper without it throws a `LogicException` with the command
+to install it. Once installed, SecurityBundle must be enabled:
+
+```bash
+composer require symfony/security-bundle
+```
+
+```php
+use App\Repository\UserRepository;
+
+public function testAuthenticatedAccess(): void
+{
+    $user = static::getContainer()
+        ->get(UserRepository::class)
+        ->findOneBy(['email' => 'admin@example.com']);
+    self::assertNotNull($user);
+
+    $this->loginUser($user, 'main', ['source' => 'playwright-test']);
+    $this->visit('/admin/users');
+
+    self::assertResponseIsSuccessful();
+    $this->assertPageContains('User Management');
+}
+```
+
+The user and every object referenced by it must be serializable when the firewall uses a session, just as with
+Symfony's standard test client. The method returns the test case for fluent setup.
+
 ### `authenticate(string $identifier = 'user', array $context = []): void`
 
 Convenience helper that sets an `AUTH` cookie with user information. This is intended as a starting point - you'll
@@ -338,9 +373,11 @@ public function testAuthenticatedAccess(): void
 **Note:** The `authenticate()` method stores data in an `AUTH` cookie as JSON. You'll need to handle this cookie in your
 application's security layer or override this method for your authentication mechanism.
 
-### `logout(): void`
+### `logout(string $firewallContext = 'main'): static`
 
-Remove the authentication cookie.
+Clear both authentication mechanisms: the legacy `AUTH` cookie and Symfony's real firewall token. For a stateful
+firewall, the selected `_security_<firewallContext>` session entry and the browser session cookie are also removed.
+The method returns the test case.
 
 **Example:**
 
@@ -351,7 +388,7 @@ public function testLogout(): void
     $this->visit('/dashboard');
     $this->assertPageContains('Dashboard');
 
-    $this->logout();
+    $this->logout('main');
     $this->visit('/dashboard');
     $this->assertPageContains('Please log in');
 }

--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -22,6 +22,7 @@ use Playwright\Symfony\Util\FormInteractor;
 use Playwright\Symfony\Util\XPathHelper;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\TestBrowserToken;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
 use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
@@ -32,11 +33,15 @@ use Symfony\Component\DomCrawler\Link;
 use Symfony\Component\DomCrawler\UriResolver;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\HttpKernel\TerminableInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Internal BrowserKit client that intercepts browser requests and routes them through Symfony's HttpKernel.
@@ -80,7 +85,7 @@ use Symfony\Component\HttpKernel\TerminableInterface;
  *
  * @final
  *
- * @extends AbstractBrowser<BrowserKitRequest, BrowserKitResponse>
+ * @extends AbstractBrowser<object, object>
  *
  * @author Simon André <smn.andre@gmail.com>
  */
@@ -331,6 +336,7 @@ class PlaywrightKernelClient extends AbstractBrowser
         }
 
         $context->addCookies([$cookie]);
+        CookieJarSync::toJarFromUrl($this->getCookieJar(), $context, $this->getBaseUrl());
     }
 
     public function getCookie(string $name, ?string $url = null): ?string
@@ -352,6 +358,7 @@ class PlaywrightKernelClient extends AbstractBrowser
     public function clearCookies(): void
     {
         $this->browser->getContext()?->clearCookies();
+        $this->getCookieJar()->clear();
     }
 
     public function clearCookie(string $name, ?string $domain = null, string $path = '/'): void
@@ -376,6 +383,7 @@ class PlaywrightKernelClient extends AbstractBrowser
         $options['expires'] = 0;
 
         $this->setCookie($name, '', $options);
+        $this->getCookieJar()->expire($name, $path, $domain);
     }
 
     /**
@@ -387,14 +395,115 @@ class PlaywrightKernelClient extends AbstractBrowser
         $this->setCookie('AUTH', $payload);
     }
 
-    public function logout(): void
+    /**
+     * @param array<string, mixed> $tokenAttributes
+     *
+     * @return $this
+     */
+    public function loginUser(object $user, string $firewallContext = 'main', array $tokenAttributes = []): static
+    {
+        $container = $this->getContainer();
+        if (null === $container) {
+            throw new \LogicException(sprintf('"%s" requires a Symfony KernelInterface instance.', __METHOD__));
+        }
+
+        if (!$container->has('security.untracked_token_storage')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
+        }
+
+        if (!$user instanceof UserInterface) {
+            throw new \LogicException(sprintf('The first argument of "%s" must be an instance of "%s", "%s" provided.', __METHOD__, UserInterface::class, get_debug_type($user)));
+        }
+
+        $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
+        $token->setAttributes($tokenAttributes);
+
+        $tokenStorage = $container->get('security.untracked_token_storage');
+        if (!$tokenStorage instanceof TokenStorageInterface) {
+            throw new \LogicException(sprintf('The "security.untracked_token_storage" service must implement "%s".', TokenStorageInterface::class));
+        }
+        $tokenStorage->setToken($token);
+
+        $session = $this->getSession();
+        if (null === $session) {
+            return $this;
+        }
+
+        try {
+            $session->set('_security_'.$firewallContext, serialize($token));
+        } catch (\Throwable $e) {
+            throw new \LogicException(sprintf('Cannot store the security token in the session: the user object of class "%s" is not serializable.', $user::class), 0, $e);
+        }
+
+        $session->save();
+        $this->setCookie($session->getName(), $session->getId(), ['httpOnly' => true]);
+
+        return $this;
+    }
+
+    public function logout(string $firewallContext = 'main'): static
     {
         $this->clearCookie('AUTH');
+
+        $container = $this->getContainer();
+        if (null === $container) {
+            return $this;
+        }
+
+        if ($container->has('security.untracked_token_storage')) {
+            $tokenStorage = $container->get('security.untracked_token_storage');
+            if ($tokenStorage instanceof TokenStorageInterface) {
+                $tokenStorage->setToken(null);
+            }
+        }
+
+        $session = $this->getSession();
+        if (null === $session) {
+            return $this;
+        }
+
+        $session->remove('_security_'.$firewallContext);
+        $session->save();
+        $this->clearCookie($session->getName());
+
+        return $this;
+    }
+
+    public function getSession(): ?SessionInterface
+    {
+        $container = $this->getContainer();
+        if (null === $container) {
+            return null;
+        }
+
+        if (!$container->has('session.factory')) {
+            return null;
+        }
+
+        $sessionFactory = $container->get('session.factory');
+        if (!$sessionFactory instanceof SessionFactoryInterface) {
+            throw new \LogicException(sprintf('The "session.factory" service must implement "%s".', SessionFactoryInterface::class));
+        }
+
+        $session = $sessionFactory->createSession();
+
+        if (null !== $sessionId = $this->getCookie($session->getName())) {
+            $session->setId($sessionId);
+        }
+
+        $session->start();
+
+        return $session;
     }
 
     public function getLastSymfonyRequest(): ?SymfonyRequest
     {
         return $this->lastSymfonyRequest;
+    }
+
+    public function getRequest(): object
+    {
+        return $this->lastSymfonyRequest ?? parent::getRequest();
     }
 
     public function getLastSymfonyResponse(): ?SymfonyResponse
@@ -431,6 +540,11 @@ class PlaywrightKernelClient extends AbstractBrowser
     public function enableProfiler(): void
     {
         $this->profileNextRequest = true;
+    }
+
+    public function getResponse(): object
+    {
+        return $this->lastSymfonyResponse ?? parent::getResponse();
     }
 
     public function getProfile(): ?Profile

--- a/src/Test/Assert/PlaywrightTestAssertionsTrait.php
+++ b/src/Test/Assert/PlaywrightTestAssertionsTrait.php
@@ -34,18 +34,6 @@ trait PlaywrightTestAssertionsTrait
         $this->assertStringNotContainsString($text, $content);
     }
 
-    protected function assertSelectorExists(string $selector): void
-    {
-        $count = $this->getPage()->locator($selector)->count();
-        $this->assertGreaterThan(0, $count, "Selector '$selector' not found");
-    }
-
-    protected function assertSelectorNotExists(string $selector): void
-    {
-        $count = $this->getPage()->locator($selector)->count();
-        $this->assertSame(0, $count, "Selector '$selector' should not exist");
-    }
-
     protected function assertSelectorVisible(string $selector): void
     {
         $this->assertTrue($this->getPage()->locator($selector)->isVisible(), "Selector '$selector' is not visible");
@@ -56,23 +44,11 @@ trait PlaywrightTestAssertionsTrait
         $this->assertTrue($this->getPage()->locator($selector)->isHidden(), "Selector '$selector' is not hidden");
     }
 
-    protected function assertSelectorTextContains(string $selector, string $text): void
-    {
-        $this->assertStringContainsString($text, $this->getPage()->locator($selector)->textContent() ?? '', "Selector '$selector' does not contain text '$text'");
-    }
-
     protected function assertResponseStatusCode(int $expectedCode): void
     {
         $response = $this->getLastResponse();
         $this->assertNotNull($response, 'No response available');
         $this->assertSame($expectedCode, $response->getStatusCode(), sprintf('Expected status code %d, got %d', $expectedCode, $response->getStatusCode()));
-    }
-
-    protected function assertResponseIsSuccessful(): void
-    {
-        $response = $this->getLastResponse();
-        $this->assertNotNull($response, 'No response available');
-        $this->assertTrue($response->isSuccessful(), sprintf('Expected successful response, got %d', $response->getStatusCode()));
     }
 
     protected function assertResponseIsRedirect(): void

--- a/src/Test/PlaywrightTestCase.php
+++ b/src/Test/PlaywrightTestCase.php
@@ -23,7 +23,7 @@ use Playwright\Symfony\Client\ResponseConverter;
 use Playwright\Symfony\Test\Assert\PlaywrightTestAssertionsTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -38,7 +38,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  * - BrowserKit-compatible API for familiar testing patterns
  *
  * Architecture overview:
- * - Extends KernelTestCase → boots Symfony kernel in test environment
+ * - Extends WebTestCase → uses Symfony's functional-test lifecycle and test container
  * - Creates shared BrowserRegistry → manages browser lifecycle across tests
  * - Creates PlaywrightKernelClient → intercepts requests and routes through kernel
  * - Provides $this->client for BrowserKit-style interactions
@@ -101,7 +101,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  *
  * @author Simon André <smn.andre@gmail.com>
  */
-abstract class PlaywrightTestCase extends KernelTestCase
+abstract class PlaywrightTestCase extends WebTestCase
 {
     use PlaywrightTestAssertionsTrait;
 
@@ -162,6 +162,7 @@ abstract class PlaywrightTestCase extends KernelTestCase
             $this->playwrightLogger,
             $this->debugLogging,
         );
+        self::getClient($this->client);
     }
 
     protected function tearDown(): void
@@ -276,9 +277,24 @@ abstract class PlaywrightTestCase extends KernelTestCase
         $this->client->authenticate($identifier, $context);
     }
 
-    protected function logout(): void
+    /**
+     * @param \Symfony\Component\Security\Core\User\UserInterface $user
+     * @param array<string, mixed>                                $tokenAttributes
+     *
+     * @return $this
+     */
+    protected function loginUser(object $user, string $firewallContext = 'main', array $tokenAttributes = []): static
     {
-        $this->client->logout();
+        $this->client->loginUser($user, $firewallContext, $tokenAttributes);
+
+        return $this;
+    }
+
+    protected function logout(string $firewallContext = 'main'): static
+    {
+        $this->client->logout($firewallContext);
+
+        return $this;
     }
 
     protected function getLastRequest(): ?SymfonyRequest

--- a/tests/Client/PlaywrightKernelClientTest.php
+++ b/tests/Client/PlaywrightKernelClientTest.php
@@ -921,6 +921,11 @@ class PlaywrightKernelClientTest extends TestCase
             {
                 return 'unserializable@example.test';
             }
+
+            // Required by symfony/security-core < 8.0.
+            public function eraseCredentials(): void
+            {
+            }
         };
 
         $this->expectException(\LogicException::class);

--- a/tests/Client/PlaywrightKernelClientTest.php
+++ b/tests/Client/PlaywrightKernelClientTest.php
@@ -30,10 +30,21 @@ use Playwright\Symfony\Tests\Client\Fixtures\FakePage;
 use Playwright\Symfony\Tests\Client\Fixtures\TestBrowserRegistry;
 use Playwright\Symfony\Tests\Fixtures\MockRequest;
 use Playwright\Symfony\Util\CookieJarSync;
+use Symfony\Bundle\FrameworkBundle\Test\TestBrowserToken;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 #[CoversClass(PlaywrightKernelClient::class)]
 #[CoversClass(BrowserRegistry::class)]
@@ -460,6 +471,7 @@ class PlaywrightKernelClientTest extends TestCase
         $lastRequest = $client->getLastSymfonyRequest();
 
         self::assertNotNull($lastRequest);
+        self::assertSame($lastRequest, $client->getRequest());
         self::assertInstanceOf(SymfonyRequest::class, $lastRequest);
         self::assertSame('/test', $lastRequest->getPathInfo());
     }
@@ -485,6 +497,7 @@ class PlaywrightKernelClientTest extends TestCase
         $lastResponse = $client->getLastSymfonyResponse();
 
         self::assertNotNull($lastResponse);
+        self::assertSame($lastResponse, $client->getResponse());
         self::assertInstanceOf(SymfonyResponse::class, $lastResponse);
         self::assertSame('test response content', $lastResponse->getContent());
     }
@@ -575,6 +588,362 @@ class PlaywrightKernelClientTest extends TestCase
 
         $client->logout();
         self::assertNull($client->getCookie('AUTH'));
+    }
+
+    public function testLogoutClearsTheSecuritySessionAndItsCookie(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $tokenStorage = new TokenStorage();
+
+        $container = new Container();
+        $container->set('session.factory', new class($session) implements SessionFactoryInterface {
+            public function __construct(private readonly SessionInterface $session)
+            {
+            }
+
+            public function createSession(): SessionInterface
+            {
+                return $this->session;
+            }
+        });
+        $container->set('security.untracked_token_storage', $tokenStorage);
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $session->start();
+        $session->set('_security_main', 'a-serialized-token');
+        $session->save();
+        $client->setCookie($session->getName(), $session->getId());
+        $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('u', null), 'main'));
+
+        $client->logout();
+
+        self::assertNull($session->get('_security_main'));
+        self::assertNull($tokenStorage->getToken());
+        self::assertNull($client->getCookie($session->getName()));
+    }
+
+    public function testLogoutTargetsTheGivenFirewallContext(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+
+        $container = new Container();
+        $container->set('session.factory', new class($session) implements SessionFactoryInterface {
+            public function __construct(private readonly SessionInterface $session)
+            {
+            }
+
+            public function createSession(): SessionInterface
+            {
+                return $this->session;
+            }
+        });
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $session->start();
+        $session->set('_security_admin', 'admin-token');
+        $session->set('_security_main', 'main-token');
+        $session->save();
+
+        $client->logout('admin');
+
+        self::assertNull($session->get('_security_admin'));
+        self::assertSame('main-token', $session->get('_security_main'));
+    }
+
+    public function testLogoutOnlyClearsCookiesWhenSessionsAreUnavailable(): void
+    {
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn(new Container());
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $client->authenticate('user');
+
+        self::assertSame($client, $client->logout());
+        self::assertNull($client->getCookie('AUTH'));
+    }
+
+    public function testLoginUserStoresTheSymfonySecurityTokenAndSessionCookie(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $tokenStorage = new TokenStorage();
+
+        $container = new Container();
+        $container->set('session.factory', new class($session) implements SessionFactoryInterface {
+            public function __construct(private readonly SessionInterface $session)
+            {
+            }
+
+            public function createSession(): SessionInterface
+            {
+                return $this->session;
+            }
+        });
+        $container->set('security.untracked_token_storage', $tokenStorage);
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+        $user = new InMemoryUser('admin@example.test', null, ['ROLE_ADMIN']);
+
+        $returned = $client->loginUser($user, 'admin', ['source' => 'unit-test']);
+
+        self::assertSame($client, $returned);
+
+        $token = $tokenStorage->getToken();
+        self::assertInstanceOf(TestBrowserToken::class, $token);
+        self::assertSame($user, $token->getUser());
+        self::assertSame('admin', $token->getFirewallName());
+        self::assertSame(['source' => 'unit-test'], $token->getAttributes());
+
+        $storedToken = unserialize((string) $session->get('_security_admin'));
+        self::assertEquals($token, $storedToken);
+        self::assertSame($session->getId(), $client->getCookie($session->getName()));
+    }
+
+    public function testLoginUserWithoutSessionMatchesSymfonyKernelBrowserBehavior(): void
+    {
+        $tokenStorage = new TokenStorage();
+        $container = new Container();
+        $container->set('security.untracked_token_storage', $tokenStorage);
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+        $user = new InMemoryUser('stateless@example.test', null, ['ROLE_USER']);
+
+        $returned = $client->loginUser($user);
+
+        self::assertSame($client, $returned);
+        self::assertSame($user, $tokenStorage->getToken()?->getUser());
+        self::assertNull($client->getCookie('MOCKSESSID'));
+    }
+
+    public function testLoginUserRejectsObjectsThatAreNotSymfonyUsers(): void
+    {
+        $container = new Container();
+        $container->set('security.untracked_token_storage', new TokenStorage());
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must be an instance of "Symfony\\Component\\Security\\Core\\User\\UserInterface", "stdClass" provided');
+
+        $client->loginUser(new \stdClass());
+    }
+
+    public function testLoginUserRequiresSecurityBundleToBeEnabled(): void
+    {
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn(new Container());
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
+
+        $client->loginUser(new InMemoryUser('user@example.test', null));
+    }
+
+    public function testLoginUserRejectsInvalidTokenStorageService(): void
+    {
+        $container = new Container();
+        $container->set('security.untracked_token_storage', new \stdClass());
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must implement "Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface"');
+
+        $client->loginUser(new InMemoryUser('user@example.test', null));
+    }
+
+    public function testLoginUserUsesTheTestServiceContainer(): void
+    {
+        $tokenStorage = new TokenStorage();
+        $testContainer = new Container();
+        $testContainer->set('security.untracked_token_storage', $tokenStorage);
+
+        $container = new Container();
+        $container->set('test.service_container', $testContainer);
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+        $user = new InMemoryUser('user@example.test', null);
+
+        self::assertSame($client, $client->loginUser($user));
+        self::assertSame($user, $tokenStorage->getToken()?->getUser());
+    }
+
+    public function testLoginUserRequiresAKernelInterface(): void
+    {
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            new class implements HttpKernelInterface {
+                public function handle(SymfonyRequest $request, int $type = self::MAIN_REQUEST, bool $catch = true): SymfonyResponse
+                {
+                    return new SymfonyResponse();
+                }
+            },
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('requires a Symfony KernelInterface instance');
+
+        $client->loginUser(new InMemoryUser('user@example.test', null));
+    }
+
+    public function testGetSessionRejectsInvalidSessionFactoryService(): void
+    {
+        $container = new Container();
+        $container->set('session.factory', new \stdClass());
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must implement "Symfony\\Component\\HttpFoundation\\Session\\SessionFactoryInterface"');
+
+        $client->getSession();
+    }
+
+    public function testLoginUserReportsAnUnserializableUser(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $container = new Container();
+        $container->set('session.factory', new class($session) implements SessionFactoryInterface {
+            public function __construct(private readonly SessionInterface $session)
+            {
+            }
+
+            public function createSession(): SessionInterface
+            {
+                return $this->session;
+            }
+        });
+        $container->set('security.untracked_token_storage', new TokenStorage());
+
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+        $user = new class implements UserInterface {
+            private \Closure $callback;
+
+            public function __construct()
+            {
+                $this->callback = static fn (): null => null;
+            }
+
+            public function getRoles(): array
+            {
+                return ['ROLE_USER'];
+            }
+
+            public function getUserIdentifier(): string
+            {
+                return 'unserializable@example.test';
+            }
+        };
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot store the security token in the session');
+
+        $client->loginUser($user);
+    }
+
+    public function testLogoutIsFluent(): void
+    {
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            new class implements HttpKernelInterface {
+                public function handle(SymfonyRequest $request, int $type = self::MAIN_REQUEST, bool $catch = true): SymfonyResponse
+                {
+                    return new SymfonyResponse('ok');
+                }
+            },
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+
+        self::assertSame($client, $client->logout());
     }
 
     public function testGetProfileReturnsNullWhenNoProfileToken(): void

--- a/tests/Fixtures/App/Controller/SecureController.php
+++ b/tests/Fixtures/App/Controller/SecureController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Fixtures\App\Controller;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SecureController
+{
+    public function __construct(private readonly Security $security)
+    {
+    }
+
+    public function __invoke(): Response
+    {
+        $user = $this->security->getUser();
+
+        return new Response(null === $user ? 'Anonymous' : 'Authenticated as '.$user->getUserIdentifier());
+    }
+}

--- a/tests/Fixtures/App/TestKernel.php
+++ b/tests/Fixtures/App/TestKernel.php
@@ -17,6 +17,7 @@ namespace Playwright\Symfony\Tests\Fixtures\App;
 use Playwright\Symfony\PlaywrightSymfonyBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
@@ -38,6 +39,7 @@ class TestKernel extends BaseKernel
     public function registerBundles(): iterable
     {
         yield new FrameworkBundle();
+        yield new SecurityBundle();
         yield new \Symfony\Bundle\TwigBundle\TwigBundle();
         yield new StimulusBundle();
         yield new TwigComponentBundle();
@@ -114,6 +116,31 @@ class TestKernel extends BaseKernel
 
         $container->extension('turbo', [
             'broadcast' => false,
+        ]);
+
+        $container->extension('security', [
+            'providers' => [
+                'test_users' => [
+                    'memory' => [
+                        'users' => [
+                            'admin@example.test' => [
+                                'password' => 'unused',
+                                'roles' => ['ROLE_ADMIN'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'firewalls' => [
+                'main' => [
+                    'lazy' => true,
+                    'provider' => 'test_users',
+                    'http_basic' => [],
+                ],
+            ],
+            'access_control' => [
+                ['path' => '^/secure$', 'roles' => 'ROLE_ADMIN'],
+            ],
         ]);
 
         // Register controllers as services with autowiring/autoconfiguration
@@ -196,6 +223,10 @@ class TestKernel extends BaseKernel
 
         $routes->add('protected', '/protected')
             ->controller([Controller\ProtectedController::class, 'index']);
+
+        $routes->add('secure', '/secure')
+            ->controller(Controller\SecureController::class)
+            ->methods(['GET']);
 
         $routes->add('form', '/form')
             ->controller([Controller\FormController::class, 'show'])

--- a/tests/Fixtures/Client/FakePlaywrightKernelClient.php
+++ b/tests/Fixtures/Client/FakePlaywrightKernelClient.php
@@ -61,9 +61,18 @@ final class FakePlaywrightKernelClient extends PlaywrightKernelClient
         $this->calls['authenticate'][] = [$identifier, $context];
     }
 
-    public function logout(): void
+    public function loginUser(object $user, string $firewallContext = 'main', array $tokenAttributes = []): static
     {
-        $this->calls['logout'][] = true;
+        $this->calls['loginUser'][] = [$user, $firewallContext, $tokenAttributes];
+
+        return $this;
+    }
+
+    public function logout(string $firewallContext = 'main'): static
+    {
+        $this->calls['logout'][] = $firewallContext;
+
+        return $this;
     }
 
     public function getLastSymfonyRequest(): ?SymfonyRequest

--- a/tests/Fixtures/Tests/TestablePlaywrightTestCase.php
+++ b/tests/Fixtures/Tests/TestablePlaywrightTestCase.php
@@ -183,9 +183,17 @@ class TestablePlaywrightTestCase extends PlaywrightTestCase
         $this->authenticate($identifier, $context);
     }
 
-    public function publicLogout(): void
+    public function publicLogout(string $firewallContext = 'main'): static
     {
-        $this->logout();
+        return $this->logout($firewallContext);
+    }
+
+    /**
+     * @param array<string, mixed> $tokenAttributes
+     */
+    public function publicLoginUser(object $user, string $firewallContext = 'main', array $tokenAttributes = []): static
+    {
+        return $this->loginUser($user, $firewallContext, $tokenAttributes);
     }
 
     public function publicGetLastRequest(): ?SymfonyRequest

--- a/tests/Functional/CookieAndAuthTest.php
+++ b/tests/Functional/CookieAndAuthTest.php
@@ -17,6 +17,7 @@ namespace Playwright\Symfony\Tests\Functional;
 use Playwright\Symfony\Test\PlaywrightTestCase;
 use Playwright\Symfony\Tests\Fixtures\App\TestKernel;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 final class CookieAndAuthTest extends PlaywrightTestCase
 {
@@ -47,5 +48,28 @@ final class CookieAndAuthTest extends PlaywrightTestCase
 
         $this->clearCookies();
         self::assertNull($this->getCookie('notice'));
+    }
+
+    public function testLoginUserAuthenticatesTheRealSymfonySecurityFirewall(): void
+    {
+        $provider = static::getContainer()->get('security.user.provider.concrete.test_users');
+        self::assertInstanceOf(UserProviderInterface::class, $provider);
+        $user = $provider->loadUserByIdentifier('admin@example.test');
+
+        $this->loginUser($user);
+        $session = $this->client->getSession();
+        self::assertNotNull($session);
+        self::assertSame($session->getId(), $this->getCookie($session->getName()));
+        self::assertNotNull($session->get('_security_main'));
+        self::assertBrowserHasCookie($session->getName());
+
+        $this->visit('/cookie');
+        $this->assertPageContains('"'.$session->getName().'":"'.$session->getId().'"');
+
+        $this->visit('/secure');
+
+        self::assertResponseIsSuccessful();
+        self::assertRouteSame('secure');
+        $this->assertPageContains('Authenticated as admin@example.test');
     }
 }

--- a/tests/Functional/HelperAssertionsTest.php
+++ b/tests/Functional/HelperAssertionsTest.php
@@ -32,6 +32,10 @@ final class HelperAssertionsTest extends PlaywrightTestCase
 
         $this->visit('/helper-demo');
 
+        self::assertResponseIsSuccessful();
+        self::assertResponseStatusCodeSame(200);
+        self::assertRouteSame('helper_demo');
+        self::assertPageTitleSame('Helper Demo');
         $this->assertPageContains('Helper Demo Ready');
         $this->assertPageNotContains('text that does not exist');
         $this->assertSelectorExists('#visible-text');

--- a/tests/Integration/SecurityIntegrationTest.php
+++ b/tests/Integration/SecurityIntegrationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Symfony\Asset\AssetMapperProxy;
+use Playwright\Symfony\Asset\FilesystemProxy;
+use Playwright\Symfony\Client\BrowserRegistry;
+use Playwright\Symfony\Client\Interception\AssetServer;
+use Playwright\Symfony\Client\PlaywrightKernelClient;
+use Playwright\Symfony\Client\RequestConverter;
+use Playwright\Symfony\Client\ResponseConverter;
+use Playwright\Symfony\Test\PlaywrightTestCase;
+use Playwright\Symfony\Tests\Client\Fixtures\FakeBrowserContext;
+use Playwright\Symfony\Tests\Client\Fixtures\FakePage;
+use Playwright\Symfony\Tests\Client\Fixtures\TestBrowserRegistry;
+use Playwright\Symfony\Tests\Fixtures\App\TestKernel;
+use Playwright\Symfony\Util\CookieJarSync;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+#[CoversClass(PlaywrightKernelClient::class)]
+#[CoversClass(PlaywrightTestCase::class)]
+#[UsesClass(AssetMapperProxy::class)]
+#[UsesClass(FilesystemProxy::class)]
+#[UsesClass(BrowserRegistry::class)]
+#[UsesClass(AssetServer::class)]
+#[UsesClass(CookieJarSync::class)]
+final class SecurityIntegrationTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    public function testLoginUserUsesSecurityBundleServicesFromTheTestContainer(): void
+    {
+        $kernel = new TestKernel('test', false);
+        $kernel->boot();
+
+        try {
+            $container = $kernel->getContainer();
+            $testContainer = $container->get('test.service_container');
+            self::assertInstanceOf(ContainerInterface::class, $testContainer);
+
+            $context = new FakeBrowserContext();
+            $browser = new TestBrowserRegistry($context, new FakePage($context));
+            $client = new PlaywrightKernelClient(
+                $browser,
+                $kernel,
+                new RequestConverter(),
+                new ResponseConverter(),
+            );
+            $user = new InMemoryUser('admin@example.test', null, ['ROLE_ADMIN']);
+
+            self::assertSame($client, $client->loginUser($user));
+
+            $tokenStorage = $testContainer->get('security.untracked_token_storage');
+            self::assertInstanceOf(TokenStorageInterface::class, $tokenStorage);
+            self::assertSame($user, $tokenStorage->getToken()?->getUser());
+
+            $session = $client->getSession();
+            self::assertNotNull($session);
+            self::assertNotNull($session->get('_security_main'));
+            self::assertSame($session->getId(), $client->getCookie($session->getName()));
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+
+    #[RunInSeparateProcess]
+    public function testPlaywrightTestCaseRegistersItsClientWithWebTestCase(): void
+    {
+        $_ENV['PLAYWRIGHT_E2E'] = '1';
+
+        $context = new FakeBrowserContext();
+        $browser = new TestBrowserRegistry($context, new FakePage($context));
+        PlaywrightSetupTestCase::setSharedBrowser($browser);
+
+        $testCase = new PlaywrightSetupTestCase('testPlaceholder');
+
+        try {
+            $testCase->runSetUp();
+
+            self::assertSame($testCase->getPlaywrightClient(), $testCase->getRegisteredClient());
+        } finally {
+            $testCase->runTearDown();
+            PlaywrightSetupTestCase::tearDownAfterClass();
+            unset($_ENV['PLAYWRIGHT_E2E']);
+        }
+    }
+}
+
+final class PlaywrightSetupTestCase extends PlaywrightTestCase
+{
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new TestKernel('test', false);
+    }
+
+    public static function setSharedBrowser(BrowserRegistry $browser): void
+    {
+        self::$sharedBrowser = $browser;
+    }
+
+    public function runSetUp(): void
+    {
+        $this->setUp();
+    }
+
+    public function runTearDown(): void
+    {
+        $this->tearDown();
+    }
+
+    public function getPlaywrightClient(): PlaywrightKernelClient
+    {
+        return $this->client;
+    }
+
+    public function getRegisteredClient(): ?AbstractBrowser
+    {
+        return self::getClient();
+    }
+
+    public function testPlaceholder(): void
+    {
+    }
+}

--- a/tests/Test/PlaywrightTestAssertionsTraitTest.php
+++ b/tests/Test/PlaywrightTestAssertionsTraitTest.php
@@ -55,34 +55,6 @@ class PlaywrightTestAssertionsTraitTest extends TestCase
         $this->assertPageNotContains('Missing Text');
     }
 
-    public function testAssertSelectorExistsUsesLocator(): void
-    {
-        $this->page = $this->createMock(PageInterface::class);
-        $locator = $this->createMock(LocatorInterface::class);
-        $locator->expects($this->once())->method('count')->willReturn(1);
-
-        $this->page->expects($this->once())
-            ->method('locator')
-            ->with('#main')
-            ->willReturn($locator);
-
-        $this->assertSelectorExists('#main');
-    }
-
-    public function testAssertSelectorNotExistsUsesLocator(): void
-    {
-        $this->page = $this->createMock(PageInterface::class);
-        $locator = $this->createMock(LocatorInterface::class);
-        $locator->expects($this->once())->method('count')->willReturn(0);
-
-        $this->page->expects($this->once())
-            ->method('locator')
-            ->with('.missing')
-            ->willReturn($locator);
-
-        $this->assertSelectorNotExists('.missing');
-    }
-
     public function testAssertSelectorVisible(): void
     {
         $this->page = $this->createMock(PageInterface::class);
@@ -111,30 +83,10 @@ class PlaywrightTestAssertionsTraitTest extends TestCase
         $this->assertSelectorHidden('.hidden');
     }
 
-    public function testAssertSelectorTextContains(): void
-    {
-        $this->page = $this->createMock(PageInterface::class);
-        $locator = $this->createMock(LocatorInterface::class);
-        $locator->expects($this->once())->method('textContent')->willReturn('The Quick Brown Fox');
-
-        $this->page->expects($this->once())
-            ->method('locator')
-            ->with('.text')
-            ->willReturn($locator);
-
-        $this->assertSelectorTextContains('.text', 'Brown Fox');
-    }
-
     public function testAssertResponseStatusCode(): void
     {
         $this->response = new Response('', 201);
         $this->assertResponseStatusCode(201);
-    }
-
-    public function testAssertResponseIsSuccessful(): void
-    {
-        $this->response = new Response('', 200);
-        $this->assertResponseIsSuccessful();
     }
 
     public function testAssertResponseIsRedirect(): void

--- a/tests/Test/PlaywrightTestCaseTest.php
+++ b/tests/Test/PlaywrightTestCaseTest.php
@@ -26,9 +26,11 @@ use Playwright\Symfony\Tests\Fixtures\MockRequest;
 use Playwright\Symfony\Tests\Fixtures\Tests\ConcretePlaywrightTestCase;
 use Playwright\Symfony\Tests\Fixtures\Tests\TestablePlaywrightTestCase;
 use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 
 #[CoversClass(PlaywrightTestCase::class)]
 #[CoversClass(RequestConverter::class)]
@@ -51,6 +53,14 @@ class PlaywrightTestCaseTest extends TestCase
         $this->lifecycleTestCase->setTestClient($this->client);
         $this->lifecycleTestCase->setTestBrowser($this->browser);
         $this->lifecycleTestCase->setTestLogger(new NullLogger());
+    }
+
+    public function testExtendsWebTestCaseAndExposesSymfonyWebAssertions(): void
+    {
+        self::assertTrue(is_subclass_of(PlaywrightTestCase::class, WebTestCase::class));
+        self::assertTrue(method_exists(PlaywrightTestCase::class, 'assertResponseIsSuccessful'));
+        self::assertTrue(method_exists(PlaywrightTestCase::class, 'assertRouteSame'));
+        self::assertTrue(method_exists(PlaywrightTestCase::class, 'assertSelectorExists'));
     }
 
     public function testConvertToSymfonyRequestHandlesGetRequest(): void
@@ -277,7 +287,7 @@ class PlaywrightTestCaseTest extends TestCase
         $this->lifecycleTestCase->publicClearCookies();
         $this->lifecycleTestCase->publicClearCookie('name', 'example.com', '/path');
         $this->lifecycleTestCase->publicAuthenticate('user', ['role' => 'admin']);
-        $this->lifecycleTestCase->publicLogout();
+        $returned = $this->lifecycleTestCase->publicLogout('admin');
 
         $this->assertSame(
             [
@@ -308,7 +318,23 @@ class PlaywrightTestCaseTest extends TestCase
             $this->client->calls['authenticate'] ?? []
         );
 
-        $this->assertSame([true], $this->client->calls['logout'] ?? []);
+        $this->assertSame($this->lifecycleTestCase, $returned);
+        $this->assertSame(['admin'], $this->client->calls['logout'] ?? []);
+    }
+
+    public function testLoginUserDelegatesToClientAndReturnsTheTestCase(): void
+    {
+        $user = new InMemoryUser('admin@example.test', null);
+
+        $returned = $this->lifecycleTestCase->publicLoginUser($user, 'admin', ['role' => 'ROLE_ADMIN']);
+
+        $this->assertSame($this->lifecycleTestCase, $returned);
+        $this->assertSame(
+            [
+                [$user, 'admin', ['role' => 'ROLE_ADMIN']],
+            ],
+            $this->client->calls['loginUser'] ?? []
+        );
     }
 
     public function testLastRequestAndResponseDelegatesToClient(): void

--- a/tests/Util/CookieJarSyncTest.php
+++ b/tests/Util/CookieJarSyncTest.php
@@ -98,4 +98,23 @@ final class CookieJarSyncTest extends TestCase
         $this->assertNotNull($jar->get('site'));
         $this->assertSame('main', $jar->get('site')->getValue());
     }
+
+    public function testPlaywrightSessionCookieRemainsValidInBrowserKitJar(): void
+    {
+        $context = new FakeBrowserContext();
+        $context->addCookies([
+            [
+                'name' => 'session',
+                'value' => 'session-id',
+                'domain' => 'localhost',
+                'path' => '/',
+                'expires' => -1,
+            ],
+        ]);
+
+        $jar = new CookieJar();
+        CookieJarSync::toJarFromUrl($jar, $context, 'http://localhost/');
+
+        $this->assertSame('session-id', $jar->get('session')?->getValue());
+    }
 }


### PR DESCRIPTION
`PlaywrightTestCase` now extends `WebTestCase`, and `loginUser()` authenticates through the real Symfony firewall instead of a fake cookie. The signature matches `KernelBrowser::loginUser()`, so moving a test over from `WebTestCase` needs no change.

`logout()` used to clear only the legacy `AUTH` cookie, which undid `authenticate()` but not `loginUser()`. It now also clears the security token and the session entry for the firewall. It takes an optional firewall context, like `loginUser()`.

Two BC breaks: the parent class changes, and `loginUser()` no longer sets the `AUTH` cookie.