### PR TITLE
Remove the PLAYWRIGHT_E2E flag in favour of PHPUnit test selection

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,8 +77,6 @@ jobs:
       matrix:
         php-version: ['8.4']
       fail-fast: false
-    env:
-      PLAYWRIGHT_E2E: '1'
     steps:
       - name: "Git: checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -202,7 +202,6 @@ jobs:
               <php>
                   <env name="APP_ENV" value="test"/>
                   <env name="KERNEL_CLASS" value="App\Kernel"/>
-                  <env name="PLAYWRIGHT_E2E" value="1"/>
                   <env name="PLAYWRIGHT_HEADLESS" value="true"/>
               </php>
           </phpunit>
@@ -395,7 +394,7 @@ jobs:
           echo "Running E2E Tests:"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          APP_ENV=test PLAYWRIGHT_E2E=1 vendor/bin/phpunit --testdox --colors=always
+          APP_ENV=test vendor/bin/phpunit --testdox --colors=always
           echo ""
           echo "✓ All tests passed"
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ playwright:
 ```
 
 > [!TIP]
-> You can override these values per test run via environment variables, e.g. `PLAYWRIGHT_BASE_URL`, `PLAYWRIGHT_E2E`, `PLAYWRIGHT_VERBOSE`, and `PLAYWRIGHT_HEADLESS`.
+> You can override these values per test run via environment variables, e.g. `PLAYWRIGHT_BASE_URL`, `PLAYWRIGHT_VERBOSE`, and `PLAYWRIGHT_HEADLESS`.
 
 See [Configuration Reference](docs/configuration.md) for all options.
 
@@ -122,14 +122,14 @@ class LoginTest extends E2ETest
 ### 3. Run Your Tests
 
 ```bash
-# Enable E2E tests and run
-PLAYWRIGHT_E2E=1 vendor/bin/phpunit tests/E2E
+# Run the E2E tests
+vendor/bin/phpunit tests/E2E
 
 # Run with visible browser for debugging
-PLAYWRIGHT_E2E=1 PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit tests/E2E
+PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit tests/E2E
 ```
 
-> **Note:** Tests are skipped by default unless `PLAYWRIGHT_E2E=1` is set.
+> **Note:** Browser tests run with the rest of your suite. Use PHPUnit's own selection (a dedicated `<testsuite>`, `--exclude-group`, `--filter`) to leave them out of a run.
 
 ## How It Works
 
@@ -296,9 +296,6 @@ public function testWithFixtures(): void
 Control test behavior with environment variables:
 
 ```bash
-# Required to run E2E tests
-PLAYWRIGHT_E2E=1
-
 # Show browser window (default: headless)
 PLAYWRIGHT_HEADLESS=false
 
@@ -319,7 +316,7 @@ KERNEL_CLASS=App\\CustomKernel
 Run tests with a visible browser to see what's happening:
 
 ```bash
-PLAYWRIGHT_E2E=1 PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit tests/E2E
+PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit tests/E2E
 ```
 
 ### Inspect Requests & Responses
@@ -375,7 +372,6 @@ jobs:
       - name: Run E2E tests
         run: vendor/bin/phpunit tests/E2E
         env:
-          PLAYWRIGHT_E2E: '1'
           PLAYWRIGHT_HEADLESS: 'true'
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,6 @@
         "cs-check": "vendor/bin/php-cs-fixer fix --dry-run --diff",
         "cs-fix": "vendor/bin/php-cs-fixer fix --diff",
         "test": "vendor/bin/phpunit",
-        "test-e2e": "PLAYWRIGHT_E2E=1 vendor/bin/phpunit"
+        "test-unit": "vendor/bin/phpunit --testsuite=unit"
     }
 }

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,7 +35,6 @@ jobs:
       - name: Run Tests
         run: vendor/bin/phpunit
         env:
-          PLAYWRIGHT_E2E: 1
           PLAYWRIGHT_HEADLESS: true
 ```
 
@@ -48,7 +47,6 @@ For GitLab, you can use a Node-capable image or install Node manually in your PH
 test:
   image: php:8.3
   variables:
-    PLAYWRIGHT_E2E: "1"
     PLAYWRIGHT_HEADLESS: "true"
   before_script:
     # Install Node.js

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,6 @@ playwright:
 
 Configuration can be overridden at runtime using environment variables:
 
-- `PLAYWRIGHT_E2E`: Set to `1` to enable browser tests.
 - `PLAYWRIGHT_BROWSER`: `chromium`, `firefox`, or `webkit`.
 - `PLAYWRIGHT_HEADLESS`: `true` or `false`.
 - `PLAYWRIGHT_BASE_URL`: Override the default base URL.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,23 +75,26 @@ class HomepageTest extends PlaywrightTestCase
 
 ## Running the Suite
 
-By default, browser tests are skipped to ensure your standard test suite remains fast. Use the `PLAYWRIGHT_E2E`
-environment variable to enable them.
+Browser tests run like any other test:
 
 ```bash
-PLAYWRIGHT_E2E=1 vendor/bin/phpunit
+vendor/bin/phpunit
 ```
+
+They are slower than the rest of your suite, so it is worth being able to run without them. Use PHPUnit's own
+selection: put them in their own `<testsuite>` (or tag them with `#[Group('e2e')]`) and skip them with
+`--testsuite=unit` or `--exclude-group=e2e`.
 
 ### Debugging & Visualization
 
 To see what is happening inside the browser during a test run, disable headless mode:
 
 ```bash
-PLAYWRIGHT_E2E=1 PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit
+PLAYWRIGHT_HEADLESS=false vendor/bin/phpunit
 ```
 
 To use a specific browser engine (default is `chromium`):
 
 ```bash
-PLAYWRIGHT_E2E=1 PLAYWRIGHT_BROWSER=firefox vendor/bin/phpunit
+PLAYWRIGHT_BROWSER=firefox vendor/bin/phpunit
 ```

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -241,7 +241,6 @@ EOF
     <php>
         <env name="APP_ENV" value="test"/>
         <env name="KERNEL_CLASS" value="App\Kernel"/>
-        <env name="PLAYWRIGHT_E2E" value="1"/>
         <env name="PLAYWRIGHT_HEADLESS" value="true"/>
     </php>
 </phpunit>
@@ -442,7 +441,7 @@ run_tests() {
     echo "Running E2E Tests:"
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo ""
-    APP_ENV=test PLAYWRIGHT_E2E=1 vendor/bin/phpunit --testdox --colors=always
+    APP_ENV=test vendor/bin/phpunit --testdox --colors=always
     echo ""
     print_success "All tests passed"
 

--- a/src/Test/PlaywrightTestCase.php
+++ b/src/Test/PlaywrightTestCase.php
@@ -62,7 +62,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  *
  * Configuration:
  * - Reads from bundle parameters: playwright.intercepted_hosts, playwright.base_url
- * - Reads from environment: PLAYWRIGHT_E2E=1 (required), PLAYWRIGHT_BROWSER, PLAYWRIGHT_HEADLESS
+ * - Reads from environment: PLAYWRIGHT_BROWSER, PLAYWRIGHT_HEADLESS
  * - Can configure via kernel container parameters
  *
  * Common methods:
@@ -97,8 +97,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  * ```
  *
  * Requirements:
- * - Set PLAYWRIGHT_E2E=1 environment variable (tests skipped otherwise)
- * - Playwright browsers installed via: npx playwright install
+ * - Playwright browsers installed via: vendor/bin/playwright-install --browsers
  *
  * @author Simon André <smn.andre@gmail.com>
  */
@@ -117,10 +116,6 @@ abstract class PlaywrightTestCase extends KernelTestCase
     {
         $this->playwrightLogger = new NullLogger();
         $this->debugLogging = false;
-
-        if ('1' !== ($_ENV['PLAYWRIGHT_E2E'] ?? $_SERVER['PLAYWRIGHT_E2E'] ?? getenv('PLAYWRIGHT_E2E'))) {
-            $this->markTestSkipped('Playwright E2E tests are disabled. Set PLAYWRIGHT_E2E=1 to enable.');
-        }
 
         parent::setUp();
         self::bootKernel();

--- a/tests/Client/BrowserRegistryTest.php
+++ b/tests/Client/BrowserRegistryTest.php
@@ -132,44 +132,6 @@ class BrowserRegistryTest extends TestCase
         $this->assertNull($refPage->getValue($browser));
     }
 
-    public function testGetContextAutoStartsIfNotStarted(): void
-    {
-        if ('1' !== ($_ENV['PLAYWRIGHT_E2E'] ?? $_SERVER['PLAYWRIGHT_E2E'] ?? getenv('PLAYWRIGHT_E2E'))) {
-            $this->markTestSkipped('Playwright E2E tests are disabled. Set PLAYWRIGHT_E2E=1 to enable.');
-        }
-
-        $browser = new BrowserRegistry('chromium', true);
-        $context = $browser->getContext();
-
-        $this->assertNotNull($context);
-
-        $browser->stop();
-    }
-
-    public function testRestartContextClosesOldContextAndStartsNew(): void
-    {
-        if ('1' !== ($_ENV['PLAYWRIGHT_E2E'] ?? $_SERVER['PLAYWRIGHT_E2E'] ?? getenv('PLAYWRIGHT_E2E'))) {
-            $this->markTestSkipped('Playwright E2E tests are disabled. Set PLAYWRIGHT_E2E=1 to enable.');
-        }
-
-        $browser = new BrowserRegistry('chromium', true);
-        $browser->start();
-
-        $firstContext = $browser->getContext();
-        $firstPage = $browser->getPage();
-
-        $browser->restartContext();
-
-        $secondContext = $browser->getContext();
-        $secondPage = $browser->getPage();
-
-        // Context and page should be different instances after restart
-        $this->assertNotSame($firstContext, $secondContext);
-        $this->assertNotSame($firstPage, $secondPage);
-
-        $browser->stop();
-    }
-
     public function testEqualsReturnsTrueForSameBrowserConfiguration(): void
     {
         $browser1 = new BrowserRegistry('chromium', true, ['arg' => 'value']);
@@ -200,44 +162,5 @@ class BrowserRegistryTest extends TestCase
         $browser2 = new BrowserRegistry('chromium', true, ['option2' => 'value2']);
 
         $this->assertFalse($browser1->equals($browser2));
-    }
-
-    public function testStartInitializesContextAndPage(): void
-    {
-        if ('1' !== ($_ENV['PLAYWRIGHT_E2E'] ?? $_SERVER['PLAYWRIGHT_E2E'] ?? getenv('PLAYWRIGHT_E2E'))) {
-            $this->markTestSkipped('Playwright E2E tests are disabled. Set PLAYWRIGHT_E2E=1 to enable.');
-        }
-
-        $browser = new BrowserRegistry('chromium', true);
-        $browser->start();
-
-        $context = $browser->getContext();
-        $page = $browser->getPage();
-
-        $this->assertNotNull($context);
-        $this->assertNotNull($page);
-
-        $browser->stop();
-    }
-
-    public function testStartIsIdempotent(): void
-    {
-        if ('1' !== ($_ENV['PLAYWRIGHT_E2E'] ?? $_SERVER['PLAYWRIGHT_E2E'] ?? getenv('PLAYWRIGHT_E2E'))) {
-            $this->markTestSkipped('Playwright E2E tests are disabled. Set PLAYWRIGHT_E2E=1 to enable.');
-        }
-
-        $browser = new BrowserRegistry('chromium', true);
-        $browser->start();
-
-        $firstContext = $browser->getContext();
-
-        // Calling start again should not create new context
-        $browser->start();
-
-        $secondContext = $browser->getContext();
-
-        $this->assertSame($firstContext, $secondContext);
-
-        $browser->stop();
     }
 }

--- a/tests/Functional/AssetMapperTest.php
+++ b/tests/Functional/AssetMapperTest.php
@@ -35,19 +35,6 @@ final class AssetMapperTest extends PlaywrightTestCase
 {
     use PlaywrightTestAssertionsTrait;
 
-    protected function setUp(): void
-    {
-        if (!self::isPlaywrightEnabled()) {
-            $this->markTestSkipped('Playwright E2E tests are disabled. Set PLAYWRIGHT_E2E=1 to enable.');
-        }
-        parent::setUp();
-    }
-
-    private static function isPlaywrightEnabled(): bool
-    {
-        return '1' === getenv('PLAYWRIGHT_E2E');
-    }
-
     protected static function createKernel(array $options = []): KernelInterface
     {
         // Use debug=false to prevent debug output in tests

--- a/tests/Integration/BrowserRegistryTest.php
+++ b/tests/Integration/BrowserRegistryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Symfony\Client\BrowserRegistry;
+
+/**
+ * BrowserRegistry behaviour that launches a real browser.
+ */
+#[CoversClass(BrowserRegistry::class)]
+class BrowserRegistryTest extends TestCase
+{
+    public function testStartInitializesContextAndPage(): void
+    {
+        $browser = new BrowserRegistry('chromium', true);
+        $browser->start();
+
+        $context = $browser->getContext();
+        $page = $browser->getPage();
+
+        $this->assertNotNull($context);
+        $this->assertNotNull($page);
+
+        $browser->stop();
+    }
+
+    public function testStartIsIdempotent(): void
+    {
+        $browser = new BrowserRegistry('chromium', true);
+        $browser->start();
+
+        $firstContext = $browser->getContext();
+
+        // Calling start again should not create new context
+        $browser->start();
+
+        $secondContext = $browser->getContext();
+
+        $this->assertSame($firstContext, $secondContext);
+
+        $browser->stop();
+    }
+
+    public function testGetContextAutoStartsIfNotStarted(): void
+    {
+        $browser = new BrowserRegistry('chromium', true);
+        $context = $browser->getContext();
+
+        $this->assertNotNull($context);
+
+        $browser->stop();
+    }
+
+    public function testRestartContextClosesOldContextAndStartsNew(): void
+    {
+        $browser = new BrowserRegistry('chromium', true);
+        $browser->start();
+
+        $firstContext = $browser->getContext();
+        $firstPage = $browser->getPage();
+
+        $browser->restartContext();
+
+        $secondContext = $browser->getContext();
+        $secondPage = $browser->getPage();
+
+        // Context and page should be different instances after restart
+        $this->assertNotSame($firstContext, $secondContext);
+        $this->assertNotSame($firstPage, $secondPage);
+
+        $browser->stop();
+    }
+}


### PR DESCRIPTION
`PlaywrightTestCase::setUp()` skips everything unless `PLAYWRIGHT_E2E=1`. PHPUnit already has its own ways to exclude tests, and this repo's CI uses them: `unit-tests` runs `--testsuite=unit`, `e2e-tests` runs `--testsuite=functional`/`integration`. The variable only re-enables tests the selector already picked, and its failure mode is a silent skip — forget it and the suite reports green having run nothing.

I think it adds complexity, and I believe it caused four tests to be skipped in this suite's CI: the browser-launching tests in `tests/Client/BrowserRegistryTest.php` live in the `unit` suite, which the `unit-tests` job runs without the flag, while the `e2e-tests` job doesn't run that suite at all. I moved them to `tests/Integration/` where the E2E job runs them; `unit` stays hermetic (251 tests, no skips).

That said, I've already found a workaround in `zenstruck/browser`, so I'm not going to die on this hill — feel free to close this if you'd rather keep the flag.
