### PR TITLE
Add `getContainer()` to the kernel client

### DIFF
--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -25,6 +25,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
 use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Link;
@@ -331,21 +332,38 @@ class PlaywrightKernelClient extends AbstractBrowser
         return $this->lastSymfonyResponse;
     }
 
+    /**
+     * The test container is preferred when available: it exposes private services, which is what
+     * tests need. Mirrors Symfony's KernelBrowser::getContainer().
+     *
+     * Null when the kernel does not expose a container (it is only typed as HttpKernelInterface).
+     */
+    public function getContainer(): ?ContainerInterface
+    {
+        if (!$this->kernel instanceof KernelInterface) {
+            return null;
+        }
+
+        $container = $this->kernel->getContainer();
+
+        if (!$container->has('test.service_container')) {
+            return $container;
+        }
+
+        $testContainer = $container->get('test.service_container');
+
+        return $testContainer instanceof ContainerInterface ? $testContainer : $container;
+    }
+
     public function getProfile(): ?Profile
     {
         if (null === $this->lastProfileToken) {
             return null;
         }
 
-        // Kernel must implement getContainer() - this is the case for Symfony\Component\HttpKernel\KernelInterface implementations
-        if (!$this->kernel instanceof KernelInterface) {
-            return null;
-        }
+        $container = $this->getContainer();
 
-        // Access the container from the kernel to get the profiler service
-        $container = $this->kernel->getContainer();
-
-        if (!$container->has('profiler')) {
+        if (!$container?->has('profiler')) {
             return null;
         }
 

--- a/tests/Integration/ContainerAccessTest.php
+++ b/tests/Integration/ContainerAccessTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Playwright\Symfony\Test\PlaywrightTestCase;
+use Playwright\Symfony\Tests\Fixtures\App\TestKernel;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[CoversNothing]
+final class ContainerAccessTest extends PlaywrightTestCase
+{
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new TestKernel('test', false);
+    }
+
+    public function testGetContainerReturnsTheContainer(): void
+    {
+        $container = $this->client->getContainer();
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertTrue($container->has('kernel'));
+    }
+
+    public function testGetContainerPrefersTheTestContainer(): void
+    {
+        $container = $this->client->getContainer();
+        $realContainer = self::$kernel?->getContainer();
+
+        self::assertNotNull($realContainer);
+        self::assertNotSame($realContainer, $container, 'expected the test container, which exposes private services');
+        self::assertSame($realContainer->get('test.service_container'), $container);
+    }
+}


### PR DESCRIPTION
`PlaywrightKernelClient` has no way to reach the container, so consumers can't get at services the way they can with `KernelBrowser`. The kernel is right there — `getProfile()` already digs through it internally.

This adds `getContainer(): ?ContainerInterface`, mirroring `Symfony\Bundle\FrameworkBundle\KernelBrowser::getContainer()`: it returns the **test container** when `framework.test` is enabled, falling back to the real one. That matters, because private services like `security.token_storage` are stripped from the real container — without the test container you get something quietly less capable than what `KernelBrowser` hands you for the same call.

It returns null when the kernel isn't a `KernelInterface`, since the constructor only requires `HttpKernelInterface`.

`getProfile()` now uses it instead of repeating the kernel/container dance.

Found while building a Playwright backend for [`zenstruck/browser`](https://github.com/zenstruck/browser), where `->use(function(ContainerInterface $c) {…})` needs the same container `KernelBrowser` provides.
