### PR TITLE
Call `$kernel->terminate()` after handling intercepted requests

### DIFF
--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\HttpKernel\TerminableInterface;
 
 /**
  * Internal BrowserKit client that intercepts browser requests and routes them through Symfony's HttpKernel.
@@ -54,7 +55,7 @@ use Symfony\Component\HttpKernel\Profiler\Profiler;
  * 2. Browser makes HTTP request → intercepted via BrowserRegistry->setupRouting()
  * 3. Request matched against interceptedHosts → if matched, proceeds to step 4
  * 4. AssetServer checks if request is for static asset → if yes, serves directly
- * 5. Otherwise: RequestConverter → HttpKernel->handle() → ResponseConverter → browser
+ * 5. Otherwise: RequestConverter → HttpKernel->handle() → Kernel->terminate() → ResponseConverter → browser
  * 6. Test can inspect via getLastSymfonyRequest(), getLastSymfonyResponse()
  *
  * Key features:
@@ -489,6 +490,10 @@ class PlaywrightKernelClient extends AbstractBrowser
             $this->lastSymfonyRequest = $symfonyRequest;
             $response = $this->kernel->handle($symfonyRequest, HttpKernelInterface::MAIN_REQUEST, false);
             $this->lastSymfonyResponse = $response;
+
+            if ($this->kernel instanceof TerminableInterface) {
+                $this->kernel->terminate($symfonyRequest, $response);
+            }
 
             if ($response->headers->has('X-Debug-Token')) {
                 $this->lastProfileToken = $response->headers->get('X-Debug-Token');

--- a/tests/Fixtures/App/EventListener/TerminateRecorder.php
+++ b/tests/Fixtures/App/EventListener/TerminateRecorder.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Fixtures\App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+
+#[AsEventListener]
+class TerminateRecorder
+{
+    /**
+     * @var string[]
+     */
+    private array $paths = [];
+
+    public function __invoke(TerminateEvent $event): void
+    {
+        $this->paths[] = $event->getRequest()->getPathInfo();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function paths(): array
+    {
+        return $this->paths;
+    }
+}

--- a/tests/Fixtures/App/TestKernel.php
+++ b/tests/Fixtures/App/TestKernel.php
@@ -62,6 +62,10 @@ class TestKernel extends BaseKernel
                 'enabled' => true,
             ],
             'test' => true,
+            'profiler' => [
+                'enabled' => true,
+                'collect' => false,
+            ],
             'asset_mapper' => [
                 'server' => true,
                 'paths' => [
@@ -89,6 +93,10 @@ class TestKernel extends BaseKernel
 
         $services
             ->load('Playwright\\Symfony\\Tests\\Fixtures\\App\\Service\\', __DIR__.'/Service/*')
+            ->public();
+
+        $services
+            ->load('Playwright\\Symfony\\Tests\\Fixtures\\App\\EventListener\\', __DIR__.'/EventListener/*')
             ->public();
 
         // Minimal Playwright config for tests

--- a/tests/Integration/KernelTerminateTest.php
+++ b/tests/Integration/KernelTerminateTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Playwright\Symfony\Test\PlaywrightTestCase;
+use Playwright\Symfony\Tests\Fixtures\App\EventListener\TerminateRecorder;
+use Playwright\Symfony\Tests\Fixtures\App\TestKernel;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+#[CoversNothing]
+final class KernelTerminateTest extends PlaywrightTestCase
+{
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new TestKernel('test', false);
+    }
+
+    public function testTerminateListenersRunForInterceptedRequests(): void
+    {
+        $recorder = self::$kernel?->getContainer()->get(TerminateRecorder::class);
+
+        self::assertInstanceOf(TerminateRecorder::class, $recorder);
+        self::assertSame([], $recorder->paths());
+
+        $this->client->visit('/hello');
+
+        self::assertSame(['/hello'], $recorder->paths());
+    }
+
+    public function testProfileIsSavedForInterceptedRequests(): void
+    {
+        $profiler = self::$kernel?->getContainer()->get('profiler');
+
+        self::assertInstanceOf(Profiler::class, $profiler);
+        $profiler->enable();
+
+        $this->client->visit('/hello');
+
+        // the profile is only written to storage on kernel.terminate
+        self::assertInstanceOf(Profile::class, $this->client->getProfile());
+    }
+}


### PR DESCRIPTION
Intercepted requests are passed to `$kernel->handle()` but the kernel is never terminated, so no `kernel.terminate` listener ever runs. Symfony's own `KernelBrowser::doRequest()` terminates after handling — anything an app defers to that event (queued messages, emails, cleanup) is silently skipped under Playwright.

The most visible casualty is the profiler, which the README already advertises. `ProfilerListener` *creates* the profile on `kernel.response` — which is why the response does carry `X-Debug-Token` and `$lastProfileToken` gets captured — but only *saves* it on `kernel.terminate`. So `getProfile()` always returned `null`, no matter how the profiler was configured.

The call is guarded with `instanceof TerminableInterface`, matching `KernelBrowser`, since the client only requires an `HttpKernelInterface`.

Two tests cover it, both failing on `main`: a `kernel.terminate` listener in the fixture app records the request it saw, and `getProfile()` returns a real `Profile`. The fixture kernel gains `framework.profiler` with `collect: false`, so the profiler stays inert unless a test enables it.