### PR TITLE
Add `enableProfiler()` to the kernel client

### DIFF
--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -93,6 +93,8 @@ class PlaywrightKernelClient extends AbstractBrowser
     private bool $interceptorSetUp = false;
     private ?AssetServer $assetServer;
     private ?string $lastProfileToken = null;
+    private bool $profileNextRequest = false;
+    private ?bool $profilerWasEnabled = null;
 
     /**
      * @param array<string, mixed> $server
@@ -356,25 +358,21 @@ class PlaywrightKernelClient extends AbstractBrowser
         return $testContainer instanceof ContainerInterface ? $testContainer : $container;
     }
 
+    /**
+     * Enable the profiler for the next request, mirroring KernelBrowser::enableProfiler().
+     */
+    public function enableProfiler(): void
+    {
+        $this->profileNextRequest = true;
+    }
+
     public function getProfile(): ?Profile
     {
         if (null === $this->lastProfileToken) {
             return null;
         }
 
-        $container = $this->getContainer();
-
-        if (!$container?->has('profiler')) {
-            return null;
-        }
-
-        $profiler = $container->get('profiler');
-
-        if (!$profiler instanceof Profiler) {
-            return null;
-        }
-
-        return $profiler->loadProfile($this->lastProfileToken);
+        return $this->profiler()?->loadProfile($this->lastProfileToken);
     }
 
     public function getBaseUrl(): string
@@ -506,6 +504,7 @@ class PlaywrightKernelClient extends AbstractBrowser
 
         try {
             $this->lastSymfonyRequest = $symfonyRequest;
+            $this->startProfiling();
             $response = $this->kernel->handle($symfonyRequest, HttpKernelInterface::MAIN_REQUEST, false);
             $this->lastSymfonyResponse = $response;
 
@@ -513,9 +512,11 @@ class PlaywrightKernelClient extends AbstractBrowser
                 $this->kernel->terminate($symfonyRequest, $response);
             }
 
-            if ($response->headers->has('X-Debug-Token')) {
-                $this->lastProfileToken = $response->headers->get('X-Debug-Token');
-            }
+            // only after terminate: that is where the profile is written to storage
+            $this->stopProfiling();
+
+            // always reassign: a request that was not profiled must not report the previous profile
+            $this->lastProfileToken = $response->headers->get('X-Debug-Token');
 
             // Only clean the buffer if we started it
             while (ob_get_level() > $bufferLevel) {
@@ -533,6 +534,8 @@ class PlaywrightKernelClient extends AbstractBrowser
 
             return $response;
         } catch (\Throwable $e) {
+            $this->stopProfiling();
+
             // Clean up output buffers even when an exception occurs
             while (ob_get_level() > $bufferLevel) {
                 ob_end_clean();
@@ -561,6 +564,53 @@ class PlaywrightKernelClient extends AbstractBrowser
         if ($this->hookReceiver && method_exists($this->hookReceiver, 'afterResponse')) {
             $this->hookReceiver->afterResponse($response);
         }
+    }
+
+    private function startProfiling(): void
+    {
+        if (!$this->profileNextRequest) {
+            return;
+        }
+
+        $this->profileNextRequest = false;
+
+        if (!$profiler = $this->profiler()) {
+            return;
+        }
+
+        $this->profilerWasEnabled = $profiler->isEnabled();
+        $profiler->enable();
+    }
+
+    /**
+     * Restores whatever state the profiler was in before the request, so an application that
+     * collects globally is not silently switched off.
+     */
+    private function stopProfiling(): void
+    {
+        if (null === $this->profilerWasEnabled) {
+            return;
+        }
+
+        $wasEnabled = $this->profilerWasEnabled;
+        $this->profilerWasEnabled = null;
+
+        if (!$wasEnabled) {
+            $this->profiler()?->disable();
+        }
+    }
+
+    private function profiler(): ?Profiler
+    {
+        $container = $this->getContainer();
+
+        if (!$container?->has('profiler')) {
+            return null;
+        }
+
+        $profiler = $container->get('profiler');
+
+        return $profiler instanceof Profiler ? $profiler : null;
     }
 
     private function ensureInterceptorSetUp(): void

--- a/tests/Integration/ProfilerTest.php
+++ b/tests/Integration/ProfilerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Playwright\Symfony\Test\PlaywrightTestCase;
+use Playwright\Symfony\Tests\Fixtures\App\TestKernel;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+#[CoversNothing]
+final class ProfilerTest extends PlaywrightTestCase
+{
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new TestKernel('test', false);
+    }
+
+    public function testNoProfileIsAvailableByDefault(): void
+    {
+        $this->client->visit('/hello');
+
+        self::assertNull($this->client->getProfile());
+    }
+
+    public function testEnableProfilerMakesTheProfileAvailable(): void
+    {
+        $this->client->enableProfiler();
+        $this->client->visit('/hello');
+
+        self::assertInstanceOf(Profile::class, $this->client->getProfile());
+    }
+
+    public function testProfilerAppliesToASingleRequest(): void
+    {
+        $this->client->enableProfiler();
+        $this->client->visit('/hello');
+
+        self::assertInstanceOf(Profile::class, $this->client->getProfile());
+
+        $this->client->visit('/hello');
+
+        self::assertNull($this->client->getProfile(), 'expected profiling to apply to one request only');
+    }
+
+    public function testGloballyEnabledProfilerStaysEnabled(): void
+    {
+        $profiler = self::$kernel?->getContainer()->get('profiler');
+
+        self::assertInstanceOf(Profiler::class, $profiler);
+        $profiler->enable();
+
+        $this->client->enableProfiler();
+        $this->client->visit('/hello');
+
+        self::assertTrue($profiler->isEnabled());
+    }
+}


### PR DESCRIPTION
The client already exposes `getProfile()` but nothing to turn the profiler on, so callers have to reach into the container themselves. This adds `enableProfiler()`, matching `KernelBrowser`'s signature and semantics — profiling applies to the *next* request only.

`KernelBrowser` gets that one-shot behaviour for free: it reboots the kernel between requests, so each one starts with a fresh, disabled profiler. Nothing reboots here, so the state has to be restored deliberately. Rather than unconditionally disabling afterwards — which would silently switch off an application that collects globally — the client records `Profiler::isEnabled()` before enabling and only disables again if it was off to begin with.

One related fix: `$lastProfileToken` was only assigned when the response carried `X-Debug-Token`, so after an unprofiled request `getProfile()` returned the *previous* request's profile. It is now reassigned every request, matching `KernelBrowser::getProfile()`, which reads the header off the current response. This surfaced as the single-request test below failing — it was handed the earlier profile.

`getProfile()`'s profiler lookup moved to a private `profiler()` helper, now shared with the enable/restore path and built on the `getContainer()` added in #36.

Depended on #37 — without terminating the kernel the profile is never written to storage, so there was nothing to load. Now that #37 and #36 are merged, this is rebased onto `main` and down to a single commit.
