### PR TITLE
Support PHP 8.2 and Symfony 6.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.3', '8.4', '8.5']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
         dependencies: ['high']
         include:
-          - php-version: '8.3'
+          - php-version: '8.2'
             dependencies: 'low'
       fail-fast: false
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,8 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
-        symfony: ['^7.4', '^8.0']
+        php: ['8.2', '8.3', '8.4']
+        symfony: ['^6.4', '^7.4', '^8.0']
+        exclude:
+          # Symfony 8 requires PHP 8.4+
+          - php: '8.2'
+            symfony: '^8.0'
 
     steps:
       - name: Checkout bundle repository

--- a/composer.json
+++ b/composer.json
@@ -26,27 +26,28 @@
         }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.2",
         "playwright-php/playwright": "^1.4",
-        "symfony/browser-kit": "^7.0 || ^8.0",
-        "symfony/framework-bundle": "^7.0 || ^8.0",
-        "symfony/http-foundation": "^7.0 || ^8.0",
-        "symfony/http-kernel": "^7.0 || ^8.0"
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-foundation": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.40",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^12.0",
-        "symfony/asset": "^7.3",
-        "symfony/asset-mapper": "^7.0 || ^8.0",
-        "symfony/css-selector": "^7.0 || ^8.0",
-        "symfony/event-dispatcher": "^7.0 || ^8.0",
-        "symfony/mime":  "^7.0 || ^8.0",
-        "symfony/phpunit-bridge": "^7.3 || ^8.0",
-        "symfony/profiler-pack": "^1.0",
-        "symfony/security-bundle": "^7.3 || ^8.0",
+        "phpunit/phpunit": "^11.5",
+        "symfony/asset": "^6.4 || ^7.0 || ^8.0",
+        "symfony/asset-mapper": "^6.4 || ^7.0 || ^8.0",
+        "symfony/css-selector": "^6.4 || ^7.0 || ^8.0",
+        "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0",
+        "symfony/mime": "^6.4 || ^7.0 || ^8.0",
+        "symfony/phpunit-bridge": "^6.4 || ^7.0 || ^8.0",
+        "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+        "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
         "symfony/ux-live-component": "^2.33 || ^3.0",
-        "symfony/ux-turbo": "^2.33 || ^3.0"
+        "symfony/ux-turbo": "^2.33 || ^3.0",
+        "symfony/web-profiler-bundle": "^6.4 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/App/TestKernel.php
+++ b/tests/Fixtures/App/TestKernel.php
@@ -48,7 +48,7 @@ class TestKernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $container): void
     {
-        $container->extension('framework', [
+        $framework = [
             'secret' => 'test-secret-for-testing',
             'router' => [
                 'utf8' => true,
@@ -76,7 +76,6 @@ class TestKernel extends BaseKernel
                 'enabled' => true,
                 'collect' => false,
             ],
-            'type_info' => true,
             'asset_mapper' => [
                 'server' => true,
                 'paths' => [
@@ -87,7 +86,14 @@ class TestKernel extends BaseKernel
                 'vendor_dir' => __DIR__.'/assets/vendor',
             ],
             'http_client' => true,
-        ]);
+        ];
+
+        // framework.type_info only exists from Symfony 7.1
+        if (BaseKernel::VERSION_ID >= 70100) {
+            $framework['type_info'] = true;
+        }
+
+        $container->extension('framework', $framework);
 
         $container->extension('twig', [
             'default_path' => __DIR__.'/templates',

--- a/tests/Functional/CompleteIntegrationFlowTest.php
+++ b/tests/Functional/CompleteIntegrationFlowTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Playwright\Symfony\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Playwright\Symfony\Test\PlaywrightTestCase;
 use Playwright\Symfony\Tests\Fixtures\App\Service\UserRepository;
 
@@ -28,10 +29,9 @@ use Playwright\Symfony\Tests\Fixtures\App\Service\UserRepository;
  * - Logout flow
  *
  * Note: Form submission with redirect skipped due to known redirect limitation in intercept mode
- *
- * @group e2e
- * @group integration
  */
+#[Group('e2e')]
+#[Group('integration')]
 final class CompleteIntegrationFlowTest extends PlaywrightTestCase
 {
     public function testCompleteUserProfileWorkflow(): void


### PR DESCRIPTION
**Lowering the floors so the most amount of people can take advantage of this package's awesomeness!** It also brings the package in line with `playwright-php/playwright`, which requires `php: ^8.2`.

Nothing in `src/` needs the higher floors — no PHP 8.3 syntax or functions, and every Symfony symbol it imports exists in 6.4. The only thing actually forcing 8.3 was `phpunit/phpunit: ^12.0`, a dev-only constraint; it drops to `^11.5`, matching `playwright`.

Verified by running the full suite at both ends: PHP 8.2.33 / Symfony 6.4.43 and PHP 8.4.24 / Symfony 8.1.4, 334 tests passing on each. CI gains PHP 8.2 and Symfony `^6.4`, excluding 8.2 + Symfony `^8.0` since Symfony 8 needs PHP 8.4+.

Two incidental changes: `symfony/profiler-pack` is replaced by the packages it pulls in, and `CompleteIntegrationFlowTest`'s `@group` doc-comments become `#[Group]` attributes, which PHPUnit 11 otherwise warns about on every run.
