### PR TITLE
Skip Playwright OS dependency install in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,6 +92,8 @@ jobs:
         uses: playwright-php/setup-playwright@v1
         with:
           browsers: chromium
+          # `ubuntu-latest` ships every library chromium needs; `--with-deps` would only add fonts these tests never render.
+          with-deps: false
 
       - name: "Composer: install"
         run: composer install --prefer-dist --no-interaction --no-progress


### PR DESCRIPTION
The `ubuntu-latest` runner image already ships every shared library chromium needs — a CI run logs `is already the newest version` for all 26 of them. The only thing `--with-deps` actually installs is nine font packages (`fonts-ipafont-gothic`, `xfonts-cyrillic`, `fonts-wqy-zenhei`, …), which this suite doesn't need: it asserts on DOM text and takes no screenshots.

Measured with an A/B matrix inside a single CI run, so both arms hit the same runner image and the same Chromium build — the `playwright install` step drops from 23.1s to 10.4s. Most of the saving is `apt-get update` (4.3s) plus the font download and dpkg work.

This is safe here specifically because the suite is chromium-only. On the same runner `--with-deps` installs 40 packages for firefox (codecs) and 181 for webkit (GStreamer, `glib-networking`), so it must not be skipped for those.

Worth revisiting if we ever add visual comparison or tests that render non-Latin text.
