### PR TITLE
Reclaim the Node process when `stop()` cannot close the context

### DIFF
--- a/src/Client/BrowserRegistry.php
+++ b/src/Client/BrowserRegistry.php
@@ -88,14 +88,18 @@ class BrowserRegistry
 
     public function stop(): void
     {
-        $this->page = null;
-        $this->context?->close();
-        $this->context = null;
+        // each close is best-effort: a broken connection - an exception thrown while handling a
+        // routed request is re-raised by every later call - would otherwise abort before the
+        // client is closed, leaving its Node process running for the rest of the PHP process
+        $this->closeQuietly($this->context);
 
         // the browser and its Node process outlive the context, so they need closing too
-        $this->browser?->close();
+        $this->closeQuietly($this->browser);
+        $this->closeQuietly($this->client);
+
+        $this->page = null;
+        $this->context = null;
         $this->browser = null;
-        $this->client?->close();
         $this->client = null;
     }
 
@@ -209,6 +213,15 @@ class BrowserRegistry
         }
 
         return $typed;
+    }
+
+    private function closeQuietly(BrowserContextInterface|BrowserInterface|PlaywrightClient|null $closable): void
+    {
+        try {
+            $closable?->close();
+        } catch (\Throwable) {
+            // already unusable, nothing left to salvage
+        }
     }
 
     private function ensureStarted(): void

--- a/tests/Client/BrowserRegistryTest.php
+++ b/tests/Client/BrowserRegistryTest.php
@@ -16,6 +16,8 @@ namespace Playwright\Symfony\Tests\Client;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Playwright\Browser\BrowserContextInterface;
+use Playwright\PlaywrightClient;
 use Playwright\Symfony\Client\BrowserRegistry;
 use Playwright\Symfony\Tests\Fixtures\Browser\DummyBrowserContext;
 use Playwright\Symfony\Tests\Fixtures\Browser\DummyPage;
@@ -130,6 +132,28 @@ class BrowserRegistryTest extends TestCase
         $this->assertTrue($context->closed);
         $this->assertNull($refContext->getValue($browser));
         $this->assertNull($refPage->getValue($browser));
+    }
+
+    public function testStopClosesTheClientWhenTheContextCannotBeClosed(): void
+    {
+        $context = $this->createMock(BrowserContextInterface::class);
+        $context->method('close')->willThrowException(new \RuntimeException('connection is broken'));
+
+        $client = $this->createMock(PlaywrightClient::class);
+        $client->expects($this->once())->method('close');
+
+        $browser = new BrowserRegistry('chromium', true);
+
+        $refContext = new \ReflectionProperty(BrowserRegistry::class, 'context');
+        $refContext->setValue($browser, $context);
+
+        $refClient = new \ReflectionProperty(BrowserRegistry::class, 'client');
+        $refClient->setValue($browser, $client);
+
+        $browser->stop();
+
+        $this->assertNull($refContext->getValue($browser));
+        $this->assertNull($refClient->getValue($browser));
     }
 
     public function testEqualsReturnsTrueForSameBrowserConfiguration(): void


### PR DESCRIPTION
`stop()` closes the context, then the browser, then the client, unguarded and in sequence. The first two are RPC calls, so on a broken connection the first one throws and `$this->client->close()` never runs — and closing the client is what terminates the Node process, via `JsonRpcTransport::disconnect()`. The process is then left running for the rest of the PHP process.

A connection breaks whenever an exception escapes a routed request: `handleInternalRequest()` calls `$kernel->handle()` with `$catch = false`, and every later call re-raises that exception — including the closes inside `stop()`.

Each close is now best-effort, so an early failure no longer prevents the client from being closed. Measured from `zenstruck/browser`, which stops a registry per test: two tests whose app threw used to leave two browsers alive until the run ended, growing with each further failure. Now it stays at one.

The new test injects a context whose `close()` throws and asserts the client is still closed and state cleared — it fails on `main` with `RuntimeException: connection is broken`.

One note: this makes `stop()` non-throwing, matching `PlaywrightClient::close()`, which already catches and logs. Happy to rethrow after the cleanup instead if you'd rather it still surfaces errors.
