### PR TITLE
Fix TypeScript asset MIME type

### DIFF
--- a/src/Asset/AssetMapperProxy.php
+++ b/src/Asset/AssetMapperProxy.php
@@ -233,6 +233,12 @@ final class AssetMapperProxy implements AssetLocatorInterface
     private function resolveMimeType(?string $extension): string
     {
         if ($extension) {
+            $extension = strtolower($extension);
+
+            if (in_array($extension, ['ts', 'mts', 'cts', 'tsx'], true)) {
+                return 'text/javascript';
+            }
+
             if (null !== $this->mime) {
                 $types = $this->mime->getMimeTypes($extension);
                 if (!empty($types)) {
@@ -254,7 +260,6 @@ final class AssetMapperProxy implements AssetLocatorInterface
                 'txt' => 'text/plain; charset=UTF-8',
             ];
 
-            $extension = strtolower($extension);
             if (isset($fallback[$extension])) {
                 return $fallback[$extension];
             }

--- a/tests/Asset/AssetMapperProxyTest.php
+++ b/tests/Asset/AssetMapperProxyTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Playwright\Symfony\Tests\Asset;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Playwright\Symfony\Asset\AssetMapperProxy;
@@ -208,6 +209,42 @@ final class AssetMapperProxyTest extends TestCase
         $proxy = new AssetMapperProxy($mapper);
         $result = $proxy->locate('/style.css');
         $this->assertSame('text/css', $result->getContentType());
+    }
+
+    #[DataProvider('typeScriptExtensions')]
+    public function testTypeScriptAssetsUseJavaScriptContentType(string $extension): void
+    {
+        $asset = (object) [
+            'publicPath' => "/controller.$extension",
+            'sourcePath' => "/assets/controller.$extension",
+            'content' => 'export default {};',
+        ];
+        $mapper = new class($asset) {
+            public function __construct(private $asset)
+            {
+            }
+
+            public function getAssetFromPublicPath($path)
+            {
+                return $this->asset;
+            }
+        };
+
+        $proxy = new AssetMapperProxy($mapper);
+        $result = $proxy->locate("/controller.$extension");
+
+        $this->assertNotNull($result);
+        $this->assertSame('text/javascript', $result->getContentType());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function typeScriptExtensions(): iterable
+    {
+        foreach (['ts', 'mts', 'cts', 'tsx'] as $extension) {
+            yield $extension => [$extension];
+        }
     }
 
     public function testOctetStreamForUnknownExtension(): void


### PR DESCRIPTION
This pull request updates how TypeScript asset files are handled by the asset mapper, ensuring they are served with the correct MIME type.

**TypeScript asset handling:**

* Updated `resolveMimeType` in `AssetMapperProxy.php` to explicitly return `'text/javascript'` for TypeScript-related extensions (`ts`, `mts`, `cts`, `tsx`) before any other MIME type logic is applied.
* Removed redundant `strtolower` call in the fallback MIME type logic, since extension normalization now happens earlier.

Fixes #44