### PR TITLE
Catch kernel exceptions by default

### DIFF
--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -166,6 +166,7 @@ class PlaywrightKernelClient extends AbstractBrowser
     private ?string $lastProfileToken = null;
     private bool $profileNextRequest = false;
     private ?bool $profilerWasEnabled = null;
+    private bool $catchExceptions = true;
 
     /**
      * @param array<string, mixed> $server
@@ -198,6 +199,11 @@ class PlaywrightKernelClient extends AbstractBrowser
             $context->addInitScript(self::FETCH_REDIRECT_SCRIPT);
             CookieJarSync::fromContext($this->getCookieJar(), $context);
         }
+    }
+
+    public function catchExceptions(bool $catchExceptions): void
+    {
+        $this->catchExceptions = $catchExceptions;
     }
 
     public function visit(string $path): PageInterface
@@ -737,7 +743,7 @@ class PlaywrightKernelClient extends AbstractBrowser
         try {
             $this->lastSymfonyRequest = $symfonyRequest;
             $this->startProfiling();
-            $response = $this->kernel->handle($symfonyRequest, HttpKernelInterface::MAIN_REQUEST, false);
+            $response = $this->kernel->handle($symfonyRequest, HttpKernelInterface::MAIN_REQUEST, $this->catchExceptions);
             $this->lastSymfonyResponse = $response;
 
             if ($this->kernel instanceof TerminableInterface) {

--- a/tests/Client/PlaywrightKernelClientTest.php
+++ b/tests/Client/PlaywrightKernelClientTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
@@ -162,6 +163,60 @@ class PlaywrightKernelClientTest extends TestCase
         // Hooks should have been called with appropriate objects
         self::assertInstanceOf(SymfonyRequest::class, $seen->before);
         self::assertInstanceOf(SymfonyResponse::class, $seen->after);
+    }
+
+    public function testInterceptedRequestsCatchKernelExceptionsByDefault(): void
+    {
+        $kernel = new class implements HttpKernelInterface {
+            public function handle(SymfonyRequest $request, int $type = self::MAIN_REQUEST, bool $catch = true): SymfonyResponse
+            {
+                if (!$catch) {
+                    throw new NotFoundHttpException();
+                }
+
+                return new SymfonyResponse('Not Found', 404);
+            }
+        };
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+        $client->visit('/page');
+
+        $route = $this->page->triggerRequest(new MockRequest(url: 'http://localhost/missing.jpg'));
+
+        self::assertTrue($route->fulfilled);
+        self::assertSame(404, $route->fulfilledOptions['status'] ?? null);
+    }
+
+    public function testKernelExceptionCatchingCanBeDisabled(): void
+    {
+        $kernel = new class implements HttpKernelInterface {
+            public function handle(SymfonyRequest $request, int $type = self::MAIN_REQUEST, bool $catch = true): SymfonyResponse
+            {
+                if (!$catch) {
+                    throw new NotFoundHttpException();
+                }
+
+                return new SymfonyResponse('Not Found', 404);
+            }
+        };
+
+        $client = new PlaywrightKernelClient(
+            $this->browser,
+            $kernel,
+            new RequestConverter(),
+            new ResponseConverter(),
+        );
+        $client->catchExceptions(false);
+        $client->visit('/page');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->page->triggerRequest(new MockRequest(url: 'http://localhost/missing.jpg'));
     }
 
     public function testDocumentRedirectUsesPlaywrightNavigationRedirect(): void

--- a/tests/Fixtures/App/Controller/ErrorController.php
+++ b/tests/Fixtures/App/Controller/ErrorController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Fixtures\App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ErrorController
+{
+    public function pageWithMissingImage(): Response
+    {
+        return new Response('<h1>Page loaded</h1><img src="/missing-image">');
+    }
+
+    public function missingImage(): never
+    {
+        throw new NotFoundHttpException();
+    }
+}

--- a/tests/Fixtures/App/TestKernel.php
+++ b/tests/Fixtures/App/TestKernel.php
@@ -232,6 +232,12 @@ class TestKernel extends BaseKernel
             ->controller([Controller\FormController::class, 'show'])
             ->methods(['GET', 'POST']);
 
+        $routes->add('page_with_missing_image', '/page-with-missing-image')
+            ->controller([Controller\ErrorController::class, 'pageWithMissingImage']);
+
+        $routes->add('missing_image', '/missing-image')
+            ->controller([Controller\ErrorController::class, 'missingImage']);
+
         $routes->add('assetmapper', '/assetmapper')
             ->controller([Controller\AssetMapperController::class, 'demo'])
             ->methods(['GET']);

--- a/tests/Functional/ErrorHandlingTest.php
+++ b/tests/Functional/ErrorHandlingTest.php
@@ -52,4 +52,12 @@ final class ErrorHandlingTest extends PlaywrightTestCase
         self::assertSame(200, $response->getStatusCode());
         $this->assertPageContains('hello from app');
     }
+
+    public function testNotFoundSubresourceDoesNotAbortThePage(): void
+    {
+        $this->visit('/page-with-missing-image');
+
+        self::assertSame(404, $this->getLastResponse()->getStatusCode());
+        $this->assertPageContains('Page loaded');
+    }
 }


### PR DESCRIPTION
This pull request introduces configurable exception handling in the `PlaywrightKernelClient`, allowing users to control whether exceptions thrown by the Symfony kernel are caught and converted to HTTP responses or allowed to propagate.

Fixes #42