### PR TITLE
Separate browser sessions

### DIFF
--- a/src/Client/BrowserRegistry.php
+++ b/src/Client/BrowserRegistry.php
@@ -55,8 +55,7 @@ class BrowserRegistry
 {
     private ?PlaywrightClient $client = null;
     private ?BrowserInterface $browser = null;
-    private ?BrowserContextInterface $context = null;
-    private ?PageInterface $page = null;
+    private ?BrowserSession $session = null;
 
     /**
      * @param array<string, mixed> $launchOptions
@@ -70,13 +69,11 @@ class BrowserRegistry
 
     public function start(): void
     {
-        if (null !== $this->context) {
+        if (null !== $this->session) {
             return;
         }
 
-        $this->browser ??= $this->launchBrowser();
-        $this->context = $this->browser->newContext($this->contextOptions());
-        $this->page = $this->context->newPage();
+        $this->session = $this->createSession();
     }
 
     public function equals(self $other): bool
@@ -91,28 +88,22 @@ class BrowserRegistry
         // each close is best-effort: a broken connection - an exception thrown while handling a
         // routed request is re-raised by every later call - would otherwise abort before the
         // client is closed, leaving its Node process running for the rest of the PHP process
-        $this->closeQuietly($this->context);
+        $this->closeQuietly($this->session);
 
         // the browser and its Node process outlive the context, so they need closing too
         $this->closeQuietly($this->browser);
         $this->closeQuietly($this->client);
 
-        $this->page = null;
-        $this->context = null;
+        $this->session = null;
         $this->browser = null;
         $this->client = null;
     }
 
     public function restartContext(): void
     {
-        if (null !== $this->page) {
-            $this->page->close();
-            $this->page = null;
-        }
-        if (null !== $this->context) {
-            $this->context->close();
-            $this->context = null;
-        }
+        $this->session?->close();
+        $this->session = null;
+
         $this->start();
     }
 
@@ -120,22 +111,20 @@ class BrowserRegistry
     {
         $this->ensureStarted();
 
-        return $this->context;
+        return $this->session?->getContext();
     }
 
     public function getPage(): ?PageInterface
     {
         $this->ensureStarted();
 
-        return $this->page;
+        return $this->session?->getPage();
     }
 
     public function setupRouting(callable $routeHandler): void
     {
         $this->ensureStarted();
-        if (null !== $this->page) {
-            $this->page->route('**/*', $routeHandler);
-        }
+        $this->session?->setupRouting($routeHandler);
     }
 
     public function isHeadless(): bool
@@ -215,7 +204,14 @@ class BrowserRegistry
         return $typed;
     }
 
-    private function closeQuietly(BrowserContextInterface|BrowserInterface|PlaywrightClient|null $closable): void
+    private function createSession(): BrowserSession
+    {
+        $this->browser ??= $this->launchBrowser();
+
+        return new BrowserSession($this->browser->newContext($this->contextOptions()));
+    }
+
+    private function closeQuietly(BrowserSession|BrowserInterface|PlaywrightClient|null $closable): void
     {
         try {
             $closable?->close();
@@ -226,7 +222,7 @@ class BrowserRegistry
 
     private function ensureStarted(): void
     {
-        if (null === $this->context) {
+        if (null === $this->session) {
             $this->start();
         }
     }

--- a/src/Client/BrowserSession.php
+++ b/src/Client/BrowserSession.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Client;
+
+use Playwright\Browser\BrowserContextInterface;
+use Playwright\Page\PageInterface;
+
+/**
+ * A browser context and its page, isolated from the browser process lifecycle.
+ *
+ * @internal
+ */
+final class BrowserSession
+{
+    private ?BrowserContextInterface $context;
+    private ?PageInterface $page;
+
+    public function __construct(BrowserContextInterface $context)
+    {
+        $this->context = $context;
+        $this->page = $context->newPage();
+    }
+
+    public function getContext(): ?BrowserContextInterface
+    {
+        return $this->context;
+    }
+
+    public function getPage(): ?PageInterface
+    {
+        return $this->page;
+    }
+
+    public function setupRouting(callable $routeHandler): void
+    {
+        $this->page?->route('**/*', $routeHandler);
+    }
+
+    public function close(): void
+    {
+        $context = $this->context;
+
+        $this->page = null;
+        $this->context = null;
+
+        $context?->close();
+    }
+}

--- a/tests/Client/BrowserRegistryTest.php
+++ b/tests/Client/BrowserRegistryTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Playwright\Browser\BrowserContextInterface;
 use Playwright\PlaywrightClient;
 use Playwright\Symfony\Client\BrowserRegistry;
+use Playwright\Symfony\Client\BrowserSession;
 use Playwright\Symfony\Tests\Fixtures\Browser\DummyBrowserContext;
 use Playwright\Symfony\Tests\Fixtures\Browser\DummyPage;
 
@@ -78,12 +79,8 @@ class BrowserRegistryTest extends TestCase
 
         $browser = new BrowserRegistry('chromium', true);
 
-        $refContext = new \ReflectionProperty(BrowserRegistry::class, 'context');
-
-        $refContext->setValue($browser, $context);
-
-        $refPage = new \ReflectionProperty(BrowserRegistry::class, 'page');
-        $refPage->setValue($browser, $page);
+        $refSession = new \ReflectionProperty(BrowserRegistry::class, 'session');
+        $refSession->setValue($browser, new BrowserSession($context));
 
         $result = $browser->getPage();
 
@@ -97,12 +94,8 @@ class BrowserRegistryTest extends TestCase
 
         $browser = new BrowserRegistry('chromium', true);
 
-        $refContext = new \ReflectionProperty(BrowserRegistry::class, 'context');
-
-        $refContext->setValue($browser, $context);
-
-        $refPage = new \ReflectionProperty(BrowserRegistry::class, 'page');
-        $refPage->setValue($browser, $page);
+        $refSession = new \ReflectionProperty(BrowserRegistry::class, 'session');
+        $refSession->setValue($browser, new BrowserSession($context));
 
         $handler = static function (): void {
         };
@@ -121,17 +114,13 @@ class BrowserRegistryTest extends TestCase
 
         $browser = new BrowserRegistry('chromium', true);
 
-        $refContext = new \ReflectionProperty(BrowserRegistry::class, 'context');
-        $refContext->setValue($browser, $context);
-
-        $refPage = new \ReflectionProperty(BrowserRegistry::class, 'page');
-        $refPage->setValue($browser, $page);
+        $refSession = new \ReflectionProperty(BrowserRegistry::class, 'session');
+        $refSession->setValue($browser, new BrowserSession($context));
 
         $browser->stop();
 
         $this->assertTrue($context->closed);
-        $this->assertNull($refContext->getValue($browser));
-        $this->assertNull($refPage->getValue($browser));
+        $this->assertNull($refSession->getValue($browser));
     }
 
     public function testStopClosesTheClientWhenTheContextCannotBeClosed(): void
@@ -144,15 +133,15 @@ class BrowserRegistryTest extends TestCase
 
         $browser = new BrowserRegistry('chromium', true);
 
-        $refContext = new \ReflectionProperty(BrowserRegistry::class, 'context');
-        $refContext->setValue($browser, $context);
+        $refSession = new \ReflectionProperty(BrowserRegistry::class, 'session');
+        $refSession->setValue($browser, new BrowserSession($context));
 
         $refClient = new \ReflectionProperty(BrowserRegistry::class, 'client');
         $refClient->setValue($browser, $client);
 
         $browser->stop();
 
-        $this->assertNull($refContext->getValue($browser));
+        $this->assertNull($refSession->getValue($browser));
         $this->assertNull($refClient->getValue($browser));
     }
 

--- a/tests/Client/BrowserSessionTest.php
+++ b/tests/Client/BrowserSessionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the community-maintained Playwright PHP project.
+ * It is not affiliated with or endorsed by Microsoft.
+ *
+ * (c) 2025-Present - Playwright PHP - https://github.com/playwright-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Playwright\Symfony\Tests\Client;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Playwright\Symfony\Client\BrowserSession;
+use Playwright\Symfony\Tests\Fixtures\Browser\DummyBrowserContext;
+use Playwright\Symfony\Tests\Fixtures\Browser\DummyPage;
+
+#[CoversClass(BrowserSession::class)]
+class BrowserSessionTest extends TestCase
+{
+    public function testOwnsContextAndPage(): void
+    {
+        $page = new DummyPage();
+        $context = new DummyBrowserContext($page);
+        $session = new BrowserSession($context);
+
+        $this->assertSame($context, $session->getContext());
+        $this->assertSame($page, $session->getPage());
+    }
+
+    public function testSetupRoutingRegistersRouteOnPage(): void
+    {
+        $page = new DummyPage();
+        $session = new BrowserSession(new DummyBrowserContext($page));
+        $handler = static function (): void {
+        };
+
+        $session->setupRouting($handler);
+
+        $this->assertSame([['**/*', $handler]], $page->routes);
+    }
+
+    public function testCloseClosesContextAndClearsState(): void
+    {
+        $context = new DummyBrowserContext(new DummyPage());
+        $session = new BrowserSession($context);
+
+        $session->close();
+
+        $this->assertTrue($context->closed);
+        $this->assertNull($session->getContext());
+        $this->assertNull($session->getPage());
+    }
+}


### PR DESCRIPTION
Keep the browser process reusable while contexts and pages have their own lifecycle.

Refs #30