### PR TITLE
Make `enableProfiler()` work for every request

### DIFF
--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -896,6 +896,14 @@ class PlaywrightKernelClient extends AbstractBrowser
 
         $this->profileNextRequest = false;
 
+        // Kernel::handle() boots the kernel, and booting an already booted kernel resets the
+        // services tagged kernel.reset, which puts the profiler back to its configured "collect"
+        // setting. Boot here so that reset happens before the profiler is enabled: otherwise every
+        // request after the first is handled with profiling switched back off.
+        if ($this->kernel instanceof KernelInterface) {
+            $this->kernel->boot();
+        }
+
         if (!$profiler = $this->profiler()) {
             return;
         }

--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -163,6 +163,7 @@ class PlaywrightKernelClient extends AbstractBrowser
     private bool $interceptorSetUp = false;
     private ?AssetServer $assetServer;
     private ?string $lastProfileToken = null;
+    private bool $continuingRedirect = false;
     private bool $profileNextRequest = false;
     private ?bool $profilerWasEnabled = null;
     private bool $catchExceptions = true;
@@ -757,6 +758,7 @@ class PlaywrightKernelClient extends AbstractBrowser
                 $fulfillOptions = $this->responseConverter->prepareFulfillOptions($response);
                 $headers = is_array($fulfillOptions['headers'] ?? null) ? $fulfillOptions['headers'] : [];
                 unset($headers['location'], $headers['Location']);
+                $this->continuingRedirect = true;
                 $route->redirectNavigationRequest(
                     UriResolver::resolve($location, $request->url()),
                     ['headers' => $headers],
@@ -825,8 +827,18 @@ class PlaywrightKernelClient extends AbstractBrowser
             // only after terminate: that is where the profile is written to storage
             $this->stopProfiling();
 
-            // always reassign: a request that was not profiled must not report the previous profile
-            $this->lastProfileToken = $response->headers->get('X-Debug-Token');
+            $token = $response->headers->get('X-Debug-Token');
+            $continuingRedirect = $this->continuingRedirect;
+            $this->continuingRedirect = false;
+
+            // a request that was not profiled must not report the previous profile, but only a
+            // fresh navigation replaces it: the hops of a redirect and the subresources of a page
+            // belong to the navigation that was profiled, and would otherwise erase its token
+            if (null !== $token) {
+                $this->lastProfileToken = $token;
+            } elseif ('document' === $playwrightRequest->resourceType() && !$continuingRedirect) {
+                $this->lastProfileToken = null;
+            }
 
             // Only clean the buffer if we started it
             while (ob_get_level() > $bufferLevel) {

--- a/tests/Integration/ProfilerTest.php
+++ b/tests/Integration/ProfilerTest.php
@@ -56,6 +56,19 @@ final class ProfilerTest extends PlaywrightTestCase
         self::assertNull(static::getPlaywrightClient()->getProfile(), 'expected profiling to apply to one request only');
     }
 
+    public function testProfileSurvivesAFollowedRedirectChain(): void
+    {
+        static::getPlaywrightClient()->enableProfiler();
+        static::getPlaywrightClient()->visit('/redirect?status=302&hops=2');
+
+        $profile = static::getPlaywrightClient()->getProfile();
+
+        // the hops after the profiled request must not erase its token
+        self::assertInstanceOf(Profile::class, $profile);
+        self::assertSame('/redirect', $profile->getUrl() ? parse_url($profile->getUrl(), \PHP_URL_PATH) : null);
+        self::assertSame(302, $profile->getStatusCode());
+    }
+
     public function testGloballyEnabledProfilerStaysEnabled(): void
     {
         $profiler = self::getContainer()->get('profiler');

--- a/tests/Integration/ProfilerTest.php
+++ b/tests/Integration/ProfilerTest.php
@@ -56,6 +56,23 @@ final class ProfilerTest extends PlaywrightTestCase
         self::assertNull(static::getPlaywrightClient()->getProfile(), 'expected profiling to apply to one request only');
     }
 
+    public function testEachRequestCanBeProfiled(): void
+    {
+        static::getPlaywrightClient()->enableProfiler();
+        static::getPlaywrightClient()->visit('/hello');
+        $first = static::getPlaywrightClient()->getProfile();
+
+        static::getPlaywrightClient()->enableProfiler();
+        static::getPlaywrightClient()->visit('/echo');
+        $second = static::getPlaywrightClient()->getProfile();
+
+        // booting the kernel resets the services tagged kernel.reset, the profiler among them, so
+        // enabling it before the request that boots is not enough
+        self::assertInstanceOf(Profile::class, $first);
+        self::assertInstanceOf(Profile::class, $second);
+        self::assertNotSame($first->getToken(), $second->getToken());
+    }
+
     public function testProfileSurvivesAFollowedRedirectChain(): void
     {
         static::getPlaywrightClient()->enableProfiler();


### PR DESCRIPTION
Two ways `getProfile()` returns null when it should not, one commit each.

Follow-up to #38, which added `enableProfiler()` and the token capture.

**1. Only the first request of a test can be profiled.**

```php
$this->client->enableProfiler();
$this->client->visit('/hello');
$this->client->getProfile();  // a profile

$this->client->enableProfiler();
$this->client->visit('/echo');
$this->client->getProfile();  // null
```

`Kernel::handle()` calls `boot()`, and booting an already booted kernel resets every service tagged `kernel.reset`. `Profiler::reset()` restores `enabled` to the configured `collect` setting, so the `enable()` from `startProfiling()` is undone before the request is handled:

```
[Profiler::reset] ServicesResetter->reset < Kernel->boot < Kernel->handle < handleInternalRequest
```

`startProfiling()` now boots the kernel first, so the reset happens before the profiler is enabled. Symfony's `KernelBrowser` never hits this because it reboots the kernel per request.

**2. A profiled request loses its token to the requests that follow it.**

`lastProfileToken` was reassigned on every intercepted request, so the hops of a followed redirect, or any subresource of a profiled page, erased the token of the request that was actually profiled. It is now replaced only by a fresh navigation, and a redirect continuation is not one.

`testEachRequestCanBeProfiled` and `testProfileSurvivesAFollowedRedirectChain` cover them, and each fails without its commit.
