### PR TITLE
Stop the browser on a redirect when `followRedirects(false)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Before 1.0, breaking changes are released in minor versions.
 
 ### Added
 
+- `followRedirects(false)` now stops the browser on a redirect response instead of following it, leaving the status and `Location` on `getLastSymfonyResponse()`. `followRedirect()` follows a stopped redirect one hop at a time.
 - Add `PlaywrightTestCase::loginUser()` with the same signature and firewall token semantics as Symfony's `KernelBrowser::loginUser()`.
 - Make Symfony's `WebTestCase` response, route, session, and DomCrawler assertions available to Playwright tests.
 

--- a/src/Client/PlaywrightKernelClient.php
+++ b/src/Client/PlaywrightKernelClient.php
@@ -168,6 +168,7 @@ class PlaywrightKernelClient extends AbstractBrowser
     private ?bool $profilerWasEnabled = null;
     private bool $catchExceptions = true;
     private readonly BrowserSessionInterface $session;
+    private ?string $pendingRedirect = null;
 
     /**
      * Creates a client that routes browser requests through a Symfony kernel.
@@ -235,6 +236,27 @@ class PlaywrightKernelClient extends AbstractBrowser
         }
 
         return $page;
+    }
+
+    /**
+     * Navigates to the target of the redirect the browser was stopped on.
+     */
+    public function followRedirect(): Crawler
+    {
+        if (null === $target = $this->pendingRedirect) {
+            throw new \LogicException('The last request was not a redirect the browser was stopped on.');
+        }
+
+        $this->pendingRedirect = null;
+        $page = $this->session->getPage();
+
+        if (null === $page) {
+            throw new \RuntimeException('No page available. Browser may not be started.');
+        }
+
+        $page->goto($target);
+
+        return $this->getCrawler();
     }
 
     /**
@@ -739,15 +761,37 @@ class PlaywrightKernelClient extends AbstractBrowser
             $response = $this->handleInternalRequest($request);
             $location = $response->headers->get('location');
             $statusCode = $response->getStatusCode();
-            if (
-                'document' === $request->resourceType()
+            $isRedirectNavigation = 'document' === $request->resourceType()
                 && (
                     in_array($statusCode, [301, 302, 303], true)
                     || ('GET' === $request->method() && in_array($statusCode, [307, 308], true))
                 )
                 && null !== $location
-                && '' !== $location
-            ) {
+                && '' !== $location;
+
+            if ('document' === $request->resourceType()) {
+                $this->pendingRedirect = null;
+            }
+
+            if ($isRedirectNavigation && !$this->isFollowingRedirects()) {
+                // stop the browser on the url that redirected, as BrowserKit does. the status and
+                // Location stay on getLastSymfonyResponse() for the caller to inspect, and the body
+                // has to go: a RedirectResponse carries a meta refresh that navigates whatever the
+                // status says
+                $this->pendingRedirect = UriResolver::resolve($location, $request->url());
+
+                if (method_exists($route, 'fulfill')) {
+                    $route->fulfill([
+                        'status' => 200,
+                        'headers' => $this->fulfillHeadersWithoutLocation($response),
+                        'body' => '',
+                    ]);
+                }
+
+                return;
+            }
+
+            if ($isRedirectNavigation) {
                 // Route::redirectNavigationRequest() is @internal in playwright-php/playwright.
                 // Depending on it is deliberate, so its absence must fail loudly: falling back to
                 // a plain fulfill() would leave the page on the 3xx with no error of any kind.
@@ -755,13 +799,10 @@ class PlaywrightKernelClient extends AbstractBrowser
                     throw new \RuntimeException(sprintf('Cannot follow the %d redirect to "%s": %s::redirectNavigationRequest() is missing. Upgrade playwright-php/playwright to 1.4.0 or later.', $statusCode, $location, get_debug_type($route)));
                 }
 
-                $fulfillOptions = $this->responseConverter->prepareFulfillOptions($response);
-                $headers = is_array($fulfillOptions['headers'] ?? null) ? $fulfillOptions['headers'] : [];
-                unset($headers['location'], $headers['Location']);
                 $this->continuingRedirect = true;
                 $route->redirectNavigationRequest(
                     UriResolver::resolve($location, $request->url()),
-                    ['headers' => $headers],
+                    ['headers' => $this->fulfillHeadersWithoutLocation($response)],
                 );
 
                 return;
@@ -774,9 +815,7 @@ class PlaywrightKernelClient extends AbstractBrowser
                 && '' !== $location
                 && method_exists($route, 'fulfill')
             ) {
-                $fulfillOptions = $this->responseConverter->prepareFulfillOptions($response);
-                $headers = is_array($fulfillOptions['headers'] ?? null) ? $fulfillOptions['headers'] : [];
-                unset($headers['location'], $headers['Location']);
+                $headers = $this->fulfillHeadersWithoutLocation($response);
                 $headers['X-Playwright-PHP-Redirect'] = UriResolver::resolve($location, $request->url());
                 $headers['X-Playwright-PHP-Redirect-Status'] = (string) $statusCode;
 
@@ -801,6 +840,18 @@ class PlaywrightKernelClient extends AbstractBrowser
     private function shouldInterceptRequest(array|false $url): bool
     {
         return is_array($url) && isset($url['host']) && in_array($url['host'], $this->interceptedHosts, true);
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function fulfillHeadersWithoutLocation(SymfonyResponse $response): array
+    {
+        $fulfillOptions = $this->responseConverter->prepareFulfillOptions($response);
+        $headers = is_array($fulfillOptions['headers'] ?? null) ? $fulfillOptions['headers'] : [];
+        unset($headers['location'], $headers['Location']);
+
+        return $headers;
     }
 
     private function handleInternalRequest(RequestInterface $playwrightRequest): SymfonyResponse

--- a/tests/Functional/RedirectTest.php
+++ b/tests/Functional/RedirectTest.php
@@ -136,6 +136,60 @@ final class RedirectTest extends PlaywrightTestCase
     /**
      * @return iterable<string, array{int}>
      */
+    public function testRedirectIsNotFollowedWhenTheClientIsToldNotTo(): void
+    {
+        static::getPlaywrightClient()->followRedirects(false);
+
+        $page = $this->visit('/redirect?status=302');
+
+        // the browser stops on the url that redirected, with nothing rendered
+        self::assertSame($this->getBaseUrl().'/redirect?status=302', $page->url());
+
+        $response = $this->getLastResponse();
+
+        self::assertNotNull($response);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('/hello', $response->headers->get('location'));
+    }
+
+    public function testStoppedRedirectCanBeFollowedOneHopAtATime(): void
+    {
+        static::getPlaywrightClient()->followRedirects(false);
+
+        $this->visit('/redirect?status=302&hops=1');
+        static::getPlaywrightClient()->followRedirect();
+
+        self::assertSame(302, $this->getLastResponse()?->getStatusCode());
+        self::assertSame($this->getBaseUrl().'/redirect?status=302&hops=0&target=%2Fhello', $this->getPage()->url());
+
+        static::getPlaywrightClient()->followRedirect();
+
+        self::assertSame(200, $this->getLastResponse()?->getStatusCode());
+        self::assertSame($this->getBaseUrl().'/hello', $this->getPage()->url());
+        $this->assertPageContains('hello from app');
+    }
+
+    public function testFollowRedirectFailsWhenTheBrowserWasNotStopped(): void
+    {
+        $this->visit('/hello');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The last request was not a redirect the browser was stopped on.');
+
+        static::getPlaywrightClient()->followRedirect();
+    }
+
+    public function testRedirectsAreFollowedAgainOnceReEnabled(): void
+    {
+        static::getPlaywrightClient()->followRedirects(false);
+        $this->visit('/redirect?status=302');
+
+        static::getPlaywrightClient()->followRedirects(true);
+        $page = $this->visit('/redirect?status=302');
+
+        self::assertSame($this->getBaseUrl().'/hello', $page->url());
+    }
+
     public static function redirectStatuses(): iterable
     {
         foreach ([301, 302, 303, 307, 308] as $status) {


### PR DESCRIPTION
`followRedirects(false)` currently does nothing. The flag is inherited from `AbstractBrowser` and `isFollowingRedirects()` reports it correctly, but the route handler follows every 3xx regardless.

This makes it stop instead: the 3xx is fulfilled as a `200` with no `Location` and an empty body, so the browser parks on the url that redirected while `getLastSymfonyResponse()` keeps the real status and `Location` for the caller to inspect. The body has to be dropped because a `RedirectResponse` carries a `<meta http-equiv="refresh">` that navigates whatever the status says.

`followRedirect()` then steps a stopped redirect one hop at a time. `fetch` redirects keep their client-side replay: `followRedirects()` is about where the test client navigates, not what application JS asked `fetch()` to do.

This is what `zenstruck/browser` needs for `interceptRedirects()`, `followRedirect()`, `assertRedirected()`, `assertRedirectedTo()` and `clickAndIntercept()`, whose existing `KernelBrowser` implementations already call exactly `followRedirects(false)`.

