### PR TITLE
Set QUERY_STRING on synthetic requests

### DIFF
--- a/src/Client/RequestConverter.php
+++ b/src/Client/RequestConverter.php
@@ -45,6 +45,7 @@ class RequestConverter
             'REMOTE_ADDR' => '127.0.0.1',
             'REQUEST_METHOD' => $method,
             'REQUEST_URI' => ($url['path'] ?? '/').(isset($url['query']) ? '?'.$url['query'] : ''),
+            'QUERY_STRING' => $url['query'] ?? '',
             'SERVER_NAME' => $url['host'] ?? 'localhost',
             'SERVER_PORT' => $url['port'] ?? 80,
             'HTTP_HOST' => $url['host'] ?? 'localhost',

--- a/tests/Client/RequestConverterTest.php
+++ b/tests/Client/RequestConverterTest.php
@@ -363,4 +363,16 @@ class RequestConverterTest extends TestCase
 
         self::assertSame('127.0.0.1', $symfony->getClientIp());
     }
+
+    public function testPopulatesQueryString(): void
+    {
+        $converter = new RequestConverter();
+        $request = new MockRequest(url: 'https://example.test/list?page=2&sort=name', method: 'GET');
+
+        $symfony = $converter->convertToSymfonyRequest($request);
+
+        self::assertSame('page=2&sort=name', $symfony->getQueryString());
+        self::assertSame('https://example.test/list?page=2&sort=name', $symfony->getUri());
+        self::assertSame('2', $symfony->query->get('page'));
+    }
 }


### PR DESCRIPTION
RequestConverter::convertToSymfonyRequest() builds the $server array with REQUEST_URI including the query string and fills the query bag separately via parse_str($url['query'] ?? '', $query) but it never sets QUERY_STRING.

Request::getQueryString() reads only that server key, and Request::getUri() is built from getQueryString().
So on a synthetic request $request->query->get('page') works while $request->getQueryString() returns null and $request->getUri() silently drops the query.
Under PHP-FPM, QUERY_STRING is always set.